### PR TITLE
fix(scholarship_treasury): require positive quorum threshold to prevent low-participation execution

### DIFF
--- a/contracts/scholarship_treasury/src/lib.rs
+++ b/contracts/scholarship_treasury/src/lib.rs
@@ -182,9 +182,7 @@ impl ScholarshipTreasury {
         }
         admin.require_auth();
 
-        if quorum_threshold < 0 {
-            panic_with_error!(&env, Error::InvalidAmount);
-        }
+        Self::validate_quorum_threshold(&env, quorum_threshold);
         if approval_bps > 10_000 {
             panic_with_error!(&env, Error::InvalidAmount);
         }
@@ -211,6 +209,10 @@ impl ScholarshipTreasury {
         Self::extend_instance(&env);
     }
 
+    /// Returns the configured quorum as an absolute minimum vote count.
+    ///
+    /// This is a hard threshold (not basis points), so proposals require
+    /// `yes_votes + no_votes >= quorum_threshold` to be eligible to pass.
     pub fn get_quorum(env: Env) -> i128 {
         Self::extend_instance(&env);
         env.storage()
@@ -230,9 +232,7 @@ impl ScholarshipTreasury {
     pub fn set_quorum(env: Env, new_quorum: i128) {
         let admin = Self::admin(&env);
         admin.require_auth();
-        if new_quorum < 0 {
-            panic_with_error!(&env, Error::InvalidAmount);
-        }
+        Self::validate_quorum_threshold(&env, new_quorum);
         env.storage().instance().set(&QUORUM_KEY, &new_quorum);
     }
 
@@ -885,6 +885,13 @@ impl ScholarshipTreasury {
             .instance()
             .get(&ADMIN_KEY)
             .unwrap_or_else(|| panic_with_error!(env, Error::NotInitialized))
+    }
+
+    fn validate_quorum_threshold(env: &Env, quorum_threshold: i128) {
+        // Quorum is an absolute vote-count floor, so it must be strictly positive.
+        if quorum_threshold <= 0 {
+            panic_with_error!(env, Error::InvalidAmount);
+        }
     }
 
     /// Replace the current contract WASM with a new uploaded hash. Admin only.

--- a/contracts/scholarship_treasury/src/test.rs
+++ b/contracts/scholarship_treasury/src/test.rs
@@ -635,6 +635,49 @@ fn double_initialize_fails() {
     );
 }
 
+#[test]
+fn initialize_with_zero_quorum_fails() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+    let gov_contract = Address::generate(&env);
+
+    let contract_id = env.register(ScholarshipTreasury, ());
+    let client = ScholarshipTreasuryClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    let result = client.try_initialize(
+        &admin,
+        &usdc_token,
+        &gov_contract,
+        &0_i128,
+        &DEFAULT_APPROVAL_BPS,
+    );
+
+    assert_eq!(
+        result.err(),
+        Some(Ok(soroban_sdk::Error::from_contract_error(
+            Error::InvalidAmount as u32
+        )))
+    );
+}
+
+#[test]
+fn set_quorum_with_zero_fails() {
+    let env = Env::default();
+    let (client, _, _, _, _, _) = setup(&env);
+
+    env.mock_all_auths();
+    let result = client.try_set_quorum(&0_i128);
+
+    assert_eq!(
+        result.err(),
+        Some(Ok(soroban_sdk::Error::from_contract_error(
+            Error::InvalidAmount as u32
+        )))
+    );
+}
+
 // ============================================================================
 // DEPOSIT TESTS
 // ============================================================================


### PR DESCRIPTION
Closes #560 
## Summary
- Enforce `quorum_threshold > 0` during `initialize` and `set_quorum`.
- Centralize quorum validation in a shared helper to prevent rule drift.
- Document quorum semantics as a hard minimum vote count (not basis points).
- Add regression tests for zero-quorum initialization and zero-quorum admin updates.

## Why
Issue #560 identified that a zero quorum value makes the quorum gate trivially true (`total_votes >= quorum_threshold`), which could allow governance execution behavior to rely on incidental guards. This change makes quorum validity explicit and enforced at all write points.

## Test plan
- [x] Added unit test: `initialize_with_zero_quorum_fails`
- [x] Added unit test: `set_quorum_with_zero_fails`
- [ ] Run `cargo test -p scholarship_treasury` locally/CI (cargo unavailable in current shell)