### PR TITLE
fix: proposal_status quorum consistency, milestone count config, and LRN mint correctness

### DIFF
--- a/contracts/course_milestone/src/lib.rs
+++ b/contracts/course_milestone/src/lib.rs
@@ -135,7 +135,7 @@ pub struct CourseMilestone;
 
 #[contractimpl]
 impl CourseMilestone {
-    pub fn initialize(env: Env, admin: Address) {
+    pub fn initialize(env: Env, admin: Address, learn_token: Address) {
         if env.storage().instance().has(&ADMIN_KEY) {
             panic_with_error!(&env, Error::AlreadyInitialized);
         }
@@ -144,7 +144,7 @@ impl CourseMilestone {
         upgrade::init(&env);
         env.storage()
             .instance()
-            .set(&LEARN_TOKEN_KEY, &learn_token_contract);
+            .set(&LEARN_TOKEN_KEY, &learn_token);
 
         Self::extend_instance(&env);
     }
@@ -331,7 +331,7 @@ impl CourseMilestone {
             .persistent()
             .get::<_, MilestoneStatus>(&state_key)
             .unwrap_or(MilestoneStatus::NotStarted);
-        Self::bump_persistent_ttl(&env, &state_key);
+        Self::extend_persistent(&env, &state_key);
 
         if current_state == MilestoneStatus::Pending || current_state == MilestoneStatus::Approved {
             panic_with_error!(&env, Error::DuplicateSubmission);
@@ -346,7 +346,7 @@ impl CourseMilestone {
             DataKey::MilestoneSubmission(learner.clone(), course_id.clone(), milestone_id);
 
         env.storage().persistent().set(&submission_key, &submission);
-        Self::bump_persistent_ttl(&env, &submission_key);
+        Self::extend_persistent(&env, &submission_key);
         env.storage()
             .persistent()
             .set(&state_key, &MilestoneStatus::Pending);
@@ -455,6 +455,17 @@ impl CourseMilestone {
             Self::extend_persistent(&env, &reward_key);
         }
 
+        // Mint LRN reward when non-zero — consistent with verify_milestone.
+        if lrn_reward > 0 {
+            let learn_token_address: Address = env
+                .storage()
+                .instance()
+                .get(&LEARN_TOKEN_KEY)
+                .unwrap_or_else(|| panic_with_error!(&env, Error::NotInitialized));
+            let learn_token_client = LearnTokenClient::new(&env, &learn_token_address);
+            learn_token_client.mint(&learner, &lrn_reward);
+        }
+
         // Increment completion count
         let count_key = DataKey::CompletedCount(learner.clone(), course_id.clone());
         let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
@@ -525,7 +536,7 @@ impl CourseMilestone {
         }
         Self::ensure_valid_milestone(&env, &course_id, milestone_id);
 
-        if tokens_amount <= 0 {
+        if tokens_amount < 0 {
             panic_with_error!(&env, Error::InvalidReward);
         }
 
@@ -546,9 +557,14 @@ impl CourseMilestone {
         let completed_key = DataKey::Completed(learner.clone(), course_id.clone(), milestone_id);
         env.storage().persistent().set(&completed_key, &true);
 
-        let learn_token_address: Address = env.storage().instance().get(&LEARN_TOKEN_KEY).unwrap();
-        let learn_token_client = LearnTokenClient::new(&env, &learn_token_address);
-        learn_token_client.mint(&learner, &tokens_amount);
+        // Only mint when reward is non-zero; zero-reward milestones (non-incentivised
+        // checkpoints) are valid and must not panic the LearnToken mint guard.
+        if tokens_amount > 0 {
+            let learn_token_address: Address =
+                env.storage().instance().get(&LEARN_TOKEN_KEY).unwrap();
+            let learn_token_client = LearnTokenClient::new(&env, &learn_token_address);
+            learn_token_client.mint(&learner, &tokens_amount);
+        }
 
         Self::extend_persistent(&env, &state_key);
         Self::extend_persistent(&env, &completed_key);
@@ -602,7 +618,7 @@ impl CourseMilestone {
             }
             Self::ensure_valid_milestone(&env, &entry.course_id, entry.milestone_id);
 
-            if entry.lrn_reward <= 0 {
+            if entry.lrn_reward < 0 {
                 panic_with_error!(&env, Error::InvalidReward);
             }
 
@@ -631,7 +647,11 @@ impl CourseMilestone {
                 entry.milestone_id,
             );
             env.storage().persistent().set(&completed_key, &true);
-            learn_token_client.mint(&entry.learner, &entry.lrn_reward);
+            // Skip mint for zero-reward entries (non-incentivised checkpoints).
+            // LearnToken::mint panics on amount <= 0, so guard before calling.
+            if entry.lrn_reward > 0 {
+                learn_token_client.mint(&entry.learner, &entry.lrn_reward);
+            }
 
             Self::extend_persistent(&env, &state_key);
             Self::extend_persistent(&env, &completed_key);

--- a/contracts/scholarship_treasury/src/lib.rs
+++ b/contracts/scholarship_treasury/src/lib.rs
@@ -35,6 +35,7 @@ const GOV_PER_USDC: i128 = 100;
 const PROPOSAL_DEADLINE_LEDGERS: u32 = 100_800;
 const QUORUM_KEY: Symbol = symbol_short!("QUORUM");
 const APPROVAL_BPS_KEY: Symbol = symbol_short!("APPBPS");
+const MILESTONE_COUNT_KEY: Symbol = symbol_short!("MSCNT");
 
 #[derive(Clone)]
 #[contracttype]
@@ -117,6 +118,8 @@ pub enum Error {
     ProposalCancelled = 16,
     Unauthorized = 17,
     ArithmeticOverflow = 18,
+    /// Milestone titles/dates count does not match the configured milestone count.
+    InvalidMilestoneCount = 19,
 }
 
 #[contract]
@@ -208,6 +211,10 @@ impl ScholarshipTreasury {
         env.storage()
             .instance()
             .set(&APPROVAL_BPS_KEY, &approval_bps);
+        // Default to 3 milestones; use set_milestone_count to override.
+        env.storage()
+            .instance()
+            .set(&MILESTONE_COUNT_KEY, &3_u32);
 
         Self::extend_instance(&env);
     }
@@ -244,6 +251,25 @@ impl ScholarshipTreasury {
             panic_with_error!(&env, Error::InvalidAmount);
         }
         env.storage().instance().set(&APPROVAL_BPS_KEY, &new_bps);
+    }
+
+    /// Returns the configured number of milestones required per proposal.
+    pub fn get_milestone_count(env: Env) -> u32 {
+        Self::extend_instance(&env);
+        env.storage()
+            .instance()
+            .get::<_, u32>(&MILESTONE_COUNT_KEY)
+            .unwrap_or(3)
+    }
+
+    /// Admin-only: update the required milestone count for future proposals.
+    pub fn set_milestone_count(env: Env, count: u32) {
+        let admin = Self::admin(&env);
+        admin.require_auth();
+        if count == 0 {
+            panic_with_error!(&env, Error::InvalidMilestoneCount);
+        }
+        env.storage().instance().set(&MILESTONE_COUNT_KEY, &count);
     }
 
     pub fn pause(env: Env) {
@@ -542,8 +568,19 @@ impl ScholarshipTreasury {
         Self::assert_initialized(&env);
         Self::assert_not_paused(&env);
 
-        if amount <= 0 || milestone_titles.len() != 3 || milestone_dates.len() != 3 {
+        if amount <= 0 {
             panic_with_error!(&env, Error::InvalidAmount);
+        }
+
+        let required_milestones = env
+            .storage()
+            .instance()
+            .get::<_, u32>(&MILESTONE_COUNT_KEY)
+            .unwrap_or(3);
+        if milestone_titles.len() != required_milestones
+            || milestone_dates.len() != required_milestones
+        {
+            panic_with_error!(&env, Error::InvalidMilestoneCount);
         }
 
         applicant.require_auth();
@@ -843,12 +880,50 @@ impl ScholarshipTreasury {
         if proposal.cancelled {
             return ProposalStatus::Rejected;
         }
+
+        // If finalize_proposal has already been called, return its stored result
+        // authoritatively — this is the single source of truth.
+        if let Some(status) = env
+            .storage()
+            .persistent()
+            .get::<_, ProposalStatus>(&DataKey::FinalizedProposal(proposal.id))
+        {
+            return status;
+        }
+
         if env.ledger().sequence() <= proposal.deadline_ledger {
             ProposalStatus::Pending
-        } else if proposal.yes_votes > proposal.no_votes {
-            ProposalStatus::Approved
         } else {
-            ProposalStatus::Rejected
+            // Apply the same quorum + approval_bps formula used in finalize_proposal
+            // and execute_proposal so all code paths are consistent.
+            let total_votes = proposal
+                .yes_votes
+                .checked_add(proposal.no_votes)
+                .unwrap_or(i128::MAX);
+            let quorum_threshold = env
+                .storage()
+                .instance()
+                .get::<_, i128>(&QUORUM_KEY)
+                .unwrap_or(0);
+            let approval_bps = env
+                .storage()
+                .instance()
+                .get::<_, u32>(&APPROVAL_BPS_KEY)
+                .unwrap_or(0);
+
+            let passed = total_votes >= quorum_threshold
+                && total_votes > 0
+                && proposal
+                    .yes_votes
+                    .checked_mul(10_000)
+                    .map(|v| (v / total_votes) as u32 > approval_bps)
+                    .unwrap_or(false);
+
+            if passed {
+                ProposalStatus::Approved
+            } else {
+                ProposalStatus::Rejected
+            }
         }
     }
 


### PR DESCRIPTION
Closes #564

---

Closes #559

---

Closes #561

---

Closes #565

---

## Summary

Fixes four bugs across `scholarship_treasury` and `course_milestone` contracts, plus three pre-existing compile errors in `course_milestone`.

---

### Bug 1 — `proposal_status` ignored quorum and approval BPS ([scholarship_treasury](contracts/scholarship_treasury/src/lib.rs))

`proposal_status` (used by `get_proposals_by_status` / `get_active_proposals`) was determining `Approved` purely by `yes_votes > no_votes`, while `finalize_proposal` and `execute_proposal` both apply quorum + approval BPS logic. This caused the two code paths to return contradictory results for the same proposal.

**Fix:** `proposal_status` now:
1. Returns the stored `FinalizedProposal` result immediately when one exists (authoritative path).
2. For unfinalized post-deadline proposals, applies the same `total_votes >= quorum_threshold && (yes × 10_000 / total) > approval_bps` formula used in `finalize_proposal` and `execute_proposal`.

---

### Bug 2 — Hard-coded milestone count of 3 with wrong error ([scholarship_treasury](contracts/scholarship_treasury/src/lib.rs))

`submit_proposal` validated exactly 3 milestone titles/dates with an undocumented magic number and fired `InvalidAmount` on mismatch.

**Fix:**
- Added `MILESTONE_COUNT_KEY` instance storage, seeded to `3` in `initialize` (backwards compatible).
- Added `Error::InvalidMilestoneCount` variant.
- Added `get_milestone_count` and `set_milestone_count` (admin-only) public functions.
- `submit_proposal` now reads the configured count and panics with `InvalidMilestoneCount` on mismatch.

---

### Bug 3 — `complete_milestone` never minted LRN tokens ([course_milestone](contracts/course_milestone/src/lib.rs))

`complete_milestone` read `lrn_reward` from storage and emitted the event with it, but never called `mint`. `verify_milestone` did call `mint`. Silent fund loss — event showed a non-zero reward but no tokens were transferred.

**Fix:** Added `if lrn_reward > 0 { learn_token_client.mint(...) }` to `complete_milestone`, consistent with `verify_milestone`.

---

### Bug 4 — Zero-reward milestones panicked `verify_milestone` and `batch_verify_milestones` ([course_milestone](contracts/course_milestone/src/lib.rs))

Both functions rejected `lrn_reward == 0` with `InvalidReward`, and `batch_verify_milestones` called `mint` unconditionally — causing `LearnToken::mint` to panic with `ZeroAmount`, rolling back the entire batch.

**Fix:** Changed the guard from `<= 0` to `< 0` (negative is still invalid) and wrapped the `mint` call in `if reward > 0 { … }` in both functions.

---

### Pre-existing compile errors fixed ([course_milestone](contracts/course_milestone/src/lib.rs))

- `initialize`: added the missing `learn_token: Address` parameter; replaced the undefined `learn_token_contract` reference.
- `submit_milestone`: replaced two calls to the undefined `bump_persistent_ttl` with the existing `extend_persistent` helper.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)