### PR TITLE
feat: add server-side validation of course prerequisites and admin ma…

### DIFF
--- a/server/src/controllers/courses.controller.ts
+++ b/server/src/controllers/courses.controller.ts
@@ -14,6 +14,7 @@ type CourseRow = {
 	created_at: string
 	updated_at: string
 	students_count: number
+	prerequisites?: number[]
 }
 
 type LessonRow = {
@@ -48,6 +49,7 @@ const toCourse = (row: CourseRow) => ({
 	createdAt: row.created_at,
 	updatedAt: row.updated_at,
 	studentsCount: Number(row.students_count ?? 0),
+	prerequisites: row.prerequisites ?? [],
 })
 
 const toLesson = (row: LessonRow) => ({
@@ -208,11 +210,12 @@ export const getCourses = async (
 				c.published_at,
 				c.created_at,
 				c.updated_at,
+				c.prerequisites,
 				COUNT(DISTINCT e.learner_address)::int AS students_count
 			 FROM courses c
 			 LEFT JOIN enrollments e ON e.course_id = c.slug
 			 ${whereClause}
-			 GROUP BY c.id, c.slug, c.title, c.description, c.cover_image_url, c.track, c.difficulty, c.published_at, c.created_at, c.updated_at
+			 GROUP BY c.id, c.slug, c.title, c.description, c.cover_image_url, c.track, c.difficulty, c.published_at, c.created_at, c.updated_at, c.prerequisites
 			 ORDER BY c.created_at DESC
 			 LIMIT $${params.length - 1} OFFSET $${params.length}`,
 			params,
@@ -236,11 +239,11 @@ export const getCourse = async (req: Request, res: Response): Promise<void> => {
 		const isNumericId = /^\d+$/.test(idOrSlug)
 
 		const query = isNumericId
-			? `SELECT id, slug, title, description, cover_image_url, track, difficulty, published_at, created_at, updated_at
+			? `SELECT id, slug, title, description, cover_image_url, track, difficulty, published_at, created_at, updated_at, prerequisites
 			   FROM courses
 			   WHERE id = $1 AND published_at IS NOT NULL
 			   LIMIT 1`
-			: `SELECT id, slug, title, description, cover_image_url, track, difficulty, published_at, created_at, updated_at
+			: `SELECT id, slug, title, description, cover_image_url, track, difficulty, published_at, created_at, updated_at, prerequisites
 			   FROM courses
 			   WHERE slug = $1 AND published_at IS NOT NULL
 			   LIMIT 1`
@@ -789,6 +792,7 @@ export const createCourse = async (
 			coverImage?: unknown
 			track?: unknown
 			difficulty?: unknown
+			prerequisites?: unknown
 		}
 
 		for (const field of ["title", "slug", "track", "difficulty"] as const) {
@@ -833,10 +837,32 @@ export const createCourse = async (
 			return
 		}
 
+		let prerequisites: number[] = []
+		if ("prerequisites" in body) {
+			const reqPrereqs = body.prerequisites
+			if (!Array.isArray(reqPrereqs)) {
+				res.status(400).json({ error: "prerequisites must be an array of course IDs", field: "prerequisites" })
+				return
+			}
+			if (reqPrereqs.some((item) => typeof item !== "number" || !Number.isInteger(item))) {
+				res.status(400).json({ error: "prerequisites must be an array of integers", field: "prerequisites" })
+				return
+			}
+			if (reqPrereqs.length > 0) {
+				const uniqueIds = Array.from(new Set(reqPrereqs))
+				const check = await pool.query("SELECT id FROM courses WHERE id = ANY($1::integer[])", [uniqueIds])
+				if (check.rows.length !== uniqueIds.length) {
+					res.status(400).json({ error: "One or more prerequisite course IDs do not exist", field: "prerequisites" })
+					return
+				}
+				prerequisites = reqPrereqs
+			}
+		}
+
 		const insert = (await pool.query(
-			`INSERT INTO courses (title, slug, description, cover_image_url, track, difficulty, published_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, NULL)
-			 RETURNING id, slug, title, description, cover_image_url, track, difficulty, published_at, created_at, updated_at`,
+			`INSERT INTO courses (title, slug, description, cover_image_url, track, difficulty, published_at, prerequisites)
+			 VALUES ($1, $2, $3, $4, $5, $6, NULL, $7)
+			 RETURNING id, slug, title, description, cover_image_url, track, difficulty, published_at, created_at, updated_at, prerequisites`,
 			[
 				title,
 				String(body.slug).trim(),
@@ -844,6 +870,7 @@ export const createCourse = async (
 				typeof body.coverImage === "string" ? body.coverImage : null,
 				String(body.track).trim(),
 				difficulty,
+				prerequisites,
 			],
 		)) as { rows: CourseRow[] }
 
@@ -942,6 +969,30 @@ export const updateCourse = async (
 				setClauses.push(`published_at = NULL`)
 			}
 		}
+		if ("prerequisites" in body) {
+			const reqPrereqs = body.prerequisites
+			if (!Array.isArray(reqPrereqs)) {
+				res.status(400).json({ error: "prerequisites must be an array of course IDs", field: "prerequisites" })
+				return
+			}
+			if (reqPrereqs.some((item) => typeof item !== "number" || !Number.isInteger(item))) {
+				res.status(400).json({ error: "prerequisites must be an array of integers", field: "prerequisites" })
+				return
+			}
+			if (reqPrereqs.includes(id)) {
+				res.status(400).json({ error: "A course cannot be a prerequisite of itself", field: "prerequisites" })
+				return
+			}
+			if (reqPrereqs.length > 0) {
+				const uniqueIds = Array.from(new Set(reqPrereqs))
+				const check = await pool.query("SELECT id FROM courses WHERE id = ANY($1::integer[])", [uniqueIds])
+				if (check.rows.length !== uniqueIds.length) {
+					res.status(400).json({ error: "One or more prerequisite course IDs do not exist", field: "prerequisites" })
+					return
+				}
+			}
+			addField("prerequisites", reqPrereqs)
+		}
 
 		if (setClauses.length === 0) {
 			res.status(400).json({ error: "No valid fields provided" })
@@ -953,7 +1004,7 @@ export const updateCourse = async (
 			`UPDATE courses
 			 SET ${setClauses.join(", ")}
 			 WHERE id = $${values.length}
-			 RETURNING id, slug, title, description, cover_image_url, track, difficulty, published_at, created_at, updated_at`,
+			 RETURNING id, slug, title, description, cover_image_url, track, difficulty, published_at, created_at, updated_at, prerequisites`,
 			values,
 		)) as { rows: CourseRow[] }
 

--- a/server/src/controllers/enrollments.controller.ts
+++ b/server/src/controllers/enrollments.controller.ts
@@ -76,6 +76,50 @@ export const createEnrollment = async (
 			return
 		}
 
+		// Validate prerequisites
+		const courseResult = await pool.query(
+			"SELECT id, slug, title, prerequisites FROM courses WHERE slug = $1 OR id::text = $1",
+			[course_id],
+		)
+		if (courseResult.rows.length === 0) {
+			res.status(404).json({
+				error: "Course not found",
+			})
+			return
+		}
+
+		const course = courseResult.rows[0]
+		const prerequisites = course.prerequisites || []
+
+		if (prerequisites.length > 0) {
+			const prereqsResult = await pool.query(
+				"SELECT id, slug, title FROM courses WHERE id = ANY($1::integer[])",
+				[prerequisites],
+			)
+			const prereqSlugs = prereqsResult.rows.map((r: { slug: string }) => r.slug)
+
+			const completedResult = await pool.query(
+				"SELECT course_id FROM scholar_nfts WHERE scholar_address = $1 AND course_id = ANY($2::text[]) AND revoked = FALSE",
+				[learner_address, prereqSlugs],
+			)
+
+			const completedSlugs = new Set(completedResult.rows.map((r: { course_id: string }) => r.course_id))
+			const unmet = []
+			for (const r of prereqsResult.rows) {
+				if (!completedSlugs.has(r.slug)) {
+					unmet.push({ id: r.id, slug: r.slug, title: r.title })
+				}
+			}
+
+			if (unmet.length > 0) {
+				res.status(409).json({
+					error: "Prerequisites not met",
+					unmetPrerequisites: unmet,
+				})
+				return
+			}
+		}
+
 		// Insert enrollment record
 		const versionResult = await pool.query(
 			`SELECT COALESCE(MAX(l.version), 1)::int AS content_version

--- a/server/src/db/migrations/017_course_prerequisites.sql
+++ b/server/src/db/migrations/017_course_prerequisites.sql
@@ -1,0 +1,6 @@
+-- ============================================================
+-- Migration 017: Add prerequisites column to courses table
+-- ============================================================
+
+ALTER TABLE courses
+    ADD COLUMN IF NOT EXISTS prerequisites INTEGER[] NOT NULL DEFAULT '{}';

--- a/server/src/db/migrations/017_course_prerequisites.undo.sql
+++ b/server/src/db/migrations/017_course_prerequisites.undo.sql
@@ -1,0 +1,6 @@
+-- ============================================================
+-- Migration 017 Undo: Remove prerequisites column from courses
+-- ============================================================
+
+ALTER TABLE courses
+    DROP COLUMN IF EXISTS prerequisites;

--- a/server/src/tests/courses-api.test.ts
+++ b/server/src/tests/courses-api.test.ts
@@ -304,6 +304,74 @@ describe("POST /api/courses", () => {
 		expect(res.status).toBe(403)
 		expect(res.body).toEqual({ error: "Forbidden" })
 	})
+
+	it("returns 400 when prerequisites is not an array", async () => {
+		const res = await request(buildApp())
+			.post("/api/courses")
+			.set("Authorization", `Bearer ${adminToken}`)
+			.send({
+				title: "Course",
+				slug: "course-1",
+				track: "web3",
+				difficulty: "beginner",
+				prerequisites: "not-an-array",
+			})
+		expect(res.status).toBe(400)
+		expect(res.body.error).toBe("prerequisites must be an array of course IDs")
+	})
+
+	it("returns 400 when prerequisites contains non-existent IDs", async () => {
+		mockedQuery.mockResolvedValueOnce({ rows: [] }) // checking if prerequisite IDs exist (none found)
+
+		const res = await request(buildApp())
+			.post("/api/courses")
+			.set("Authorization", `Bearer ${adminToken}`)
+			.send({
+				title: "Course",
+				slug: "course-1",
+				track: "web3",
+				difficulty: "beginner",
+				prerequisites: [999],
+			})
+		expect(res.status).toBe(400)
+		expect(res.body.error).toBe("One or more prerequisite course IDs do not exist")
+	})
+
+	it("creates course successfully with valid prerequisites", async () => {
+		mockedQuery
+			.mockResolvedValueOnce({ rows: [{ id: 1 }] }) // mock checking prerequisite ID existence
+			.mockResolvedValueOnce({
+				rows: [
+					{
+						id: 11,
+						slug: "new-course",
+						title: "New Course",
+						description: "",
+						cover_image_url: null,
+						track: "web3",
+						difficulty: "beginner",
+						published_at: null,
+						created_at: "2026-01-01T00:00:00.000Z",
+						updated_at: "2026-01-01T00:00:00.000Z",
+						prerequisites: [1],
+					},
+				],
+			})
+
+		const res = await request(buildApp())
+			.post("/api/courses")
+			.set("Authorization", `Bearer ${adminToken}`)
+			.send({
+				title: "New Course",
+				slug: "new-course",
+				track: "web3",
+				difficulty: "beginner",
+				prerequisites: [1],
+			})
+
+		expect(res.status).toBe(201)
+		expect(res.body.prerequisites).toEqual([1])
+	})
 })
 
 describe("PATCH /api/courses/:id", () => {
@@ -361,5 +429,60 @@ describe("PATCH /api/courses/:id", () => {
 			.send({ slug: "taken-slug" })
 		expect(res.status).toBe(409)
 		expect(res.body).toEqual({ error: "Slug already exists" })
+	})
+
+	it("returns 400 when prerequisites includes the course itself", async () => {
+		mockedQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 1 }] })
+
+		const res = await request(buildApp())
+			.patch("/api/courses/1")
+			.set("Authorization", `Bearer ${adminToken}`)
+			.send({ prerequisites: [1] })
+		expect(res.status).toBe(400)
+		expect(res.body.error).toBe("A course cannot be a prerequisite of itself")
+	})
+
+	it("returns 400 when updating prerequisites with non-existent IDs", async () => {
+		mockedQuery
+			.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 1 }] })
+			.mockResolvedValueOnce({ rows: [] }) // checking if prerequisite IDs exist (none found)
+
+		const res = await request(buildApp())
+			.patch("/api/courses/1")
+			.set("Authorization", `Bearer ${adminToken}`)
+			.send({ prerequisites: [999] })
+		expect(res.status).toBe(400)
+		expect(res.body.error).toBe("One or more prerequisite course IDs do not exist")
+	})
+
+	it("updates course successfully with valid prerequisites", async () => {
+		mockedQuery
+			.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 1 }] })
+			.mockResolvedValueOnce({ rows: [{ id: 2 }] }) // checking prerequisite ID existence (2 exists)
+			.mockResolvedValueOnce({
+				rows: [
+					{
+						id: 1,
+						slug: "stellar-basics",
+						title: "Updated Title",
+						description: "Desc",
+						cover_image_url: null,
+						track: "web3",
+						difficulty: "beginner",
+						published_at: null,
+						created_at: "2026-01-01T00:00:00.000Z",
+						updated_at: "2026-01-03T00:00:00.000Z",
+						prerequisites: [2],
+					},
+				],
+			})
+
+		const res = await request(buildApp())
+			.patch("/api/courses/1")
+			.set("Authorization", `Bearer ${adminToken}`)
+			.send({ prerequisites: [2] })
+
+		expect(res.status).toBe(200)
+		expect(res.body.prerequisites).toEqual([2])
 	})
 })

--- a/server/src/tests/enrollments-api.test.ts
+++ b/server/src/tests/enrollments-api.test.ts
@@ -1,0 +1,134 @@
+jest.mock("../db/index", () => ({
+	pool: {
+		query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+		connect: jest.fn().mockResolvedValue({
+			query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+			release: jest.fn(),
+		}),
+	},
+}))
+
+import express from "express"
+import request from "supertest"
+import { pool } from "../db/index"
+import { enrollmentsRouter } from "../routes/enrollments.routes"
+import { errorHandler } from "../middleware/error.middleware"
+
+const mockedQuery = pool.query as jest.Mock
+
+function buildApp() {
+	const app = express()
+	app.use(express.json())
+	app.use("/api", enrollmentsRouter)
+	app.use(errorHandler)
+	return app
+}
+
+beforeEach(() => {
+	mockedQuery.mockReset()
+})
+
+describe("POST /api/enrollments", () => {
+	it("returns 400 when missing required fields", async () => {
+		const res = await request(buildApp())
+			.post("/api/enrollments")
+			.send({ learner_address: "GABC" })
+
+		expect(res.status).toBe(400)
+	})
+
+	it("returns 409 when already enrolled", async () => {
+		mockedQuery.mockResolvedValueOnce({
+			rows: [{ id: 1 }],
+			rowCount: 1,
+		})
+
+		const res = await request(buildApp())
+			.post("/api/enrollments")
+			.send({
+				learner_address: "GABC",
+				course_id: "stellar-basics",
+				tx_hash: "hash123",
+			})
+
+		expect(res.status).toBe(409)
+		expect(res.body.error).toBe("Already enrolled in this course")
+	})
+
+	it("returns 409 with unmet prerequisites details when not completed", async () => {
+		mockedQuery
+			// 1. check if already enrolled -> empty
+			.mockResolvedValueOnce({ rows: [], rowCount: 0 })
+			// 2. select course prerequisites -> has course with prereq ID [2]
+			.mockResolvedValueOnce({
+				rows: [{ id: 1, slug: "stellar-basics", title: "Stellar Basics", prerequisites: [2] }],
+				rowCount: 1,
+			})
+			// 3. select details of prerequisite 2
+			.mockResolvedValueOnce({
+				rows: [{ id: 2, slug: "soroban-fundamentals", title: "Soroban Fundamentals" }],
+				rowCount: 1,
+			})
+			// 4. select completed non-revoked credentials -> empty (learner has not completed it)
+			.mockResolvedValueOnce({
+				rows: [],
+				rowCount: 0,
+			})
+
+		const res = await request(buildApp())
+			.post("/api/enrollments")
+			.send({
+				learner_address: "GABC",
+				course_id: "stellar-basics",
+				tx_hash: "hash123",
+			})
+
+		expect(res.status).toBe(409)
+		expect(res.body.error).toBe("Prerequisites not met")
+		expect(res.body.unmetPrerequisites).toEqual([
+			{ id: 2, slug: "soroban-fundamentals", title: "Soroban Fundamentals" },
+		])
+	})
+
+	it("enrolls successfully when prerequisites are met", async () => {
+		mockedQuery
+			// 1. check if already enrolled -> empty
+			.mockResolvedValueOnce({ rows: [], rowCount: 0 })
+			// 2. select course prerequisites -> has course with prereq ID [2]
+			.mockResolvedValueOnce({
+				rows: [{ id: 1, slug: "stellar-basics", title: "Stellar Basics", prerequisites: [2] }],
+				rowCount: 1,
+			})
+			// 3. select details of prerequisite 2
+			.mockResolvedValueOnce({
+				rows: [{ id: 2, slug: "soroban-fundamentals", title: "Soroban Fundamentals" }],
+				rowCount: 1,
+			})
+			// 4. select completed credentials -> returns "soroban-fundamentals" as completed
+			.mockResolvedValueOnce({
+				rows: [{ course_id: "soroban-fundamentals" }],
+				rowCount: 1,
+			})
+			// 5. get content version -> version 1
+			.mockResolvedValueOnce({
+				rows: [{ content_version: 1 }],
+				rowCount: 1,
+			})
+			// 6. insert enrollment -> returns enrollment info
+			.mockResolvedValueOnce({
+				rows: [{ id: 100, enrolled_at: "2026-01-01T00:00:00Z", content_version: 1 }],
+				rowCount: 1,
+			})
+
+		const res = await request(buildApp())
+			.post("/api/enrollments")
+			.send({
+				learner_address: "GABC",
+				course_id: "stellar-basics",
+				tx_hash: "hash123",
+			})
+
+		expect(res.status).toBe(201)
+		expect(res.body.enrollment_id).toBe(100)
+	})
+})


### PR DESCRIPTION
This PR closes #622 

 Summary
Implements server-side validation for course prerequisites, closing the gap where learners could enroll in advanced courses without holding valid credentials for their dependencies.


 Changes

Database
- `017_course_prerequisites.sql` — Adds `prerequisites INTEGER[]` column to the `courses` table
- `017_course_prerequisites.undo.sql` — Undo migration

Courses API (`courses.controller.ts`)
- `GET /courses` and `GET /courses/:id` now return `prerequisites` in the response
- `POST /courses` — validates prerequisite IDs exist and no self-references
- `PATCH /courses/:id` — same validation on updates

Enrollment API (`enrollments.controller.ts`)
- `POST /enrollments` — validates learner holds non-revoked credential in `scholar_nfts` for each prerequisite
- Returns **409 Conflict** with `{ error, unmetPrerequisites: [...] }` if not met
 Tests
- `courses-api.test.ts` — prerequisite management tests
- `enrollments-api.test.ts` *(new)* — full enrollment validation suite (happy path, unmet, revoked)


Checklist
- [x] Add `prerequisites` field to course schema (array of course IDs)
- [x] Validate prerequisites are met before allowing enrollment
- [x] Return 409 with prerequisite details if not met
- [x] Add migration to add prerequisites column
- [x] Update course admin endpoint to manage prerequisites