### PR TITLE
feat(learn_token): add proptest property-based tests for arithmetic i…

### DIFF
--- a/contracts/learn_token/src/lib.rs
+++ b/contracts/learn_token/src/lib.rs
@@ -33,15 +33,6 @@ const INSTANCE_EXTEND_TO: u32 = DAY_IN_LEDGERS * 30; // 30 days
 const PERSISTENT_BUMP_THRESHOLD: u32 = DAY_IN_LEDGERS;
 const PERSISTENT_EXTEND_TO: u32 = DAY_IN_LEDGERS * 365; // 1 year
 
-// ---------------------------------------------------------------------------
-// Storage Constants (assuming ~6s ledger time)
-// ---------------------------------------------------------------------------
-
-const DAY_IN_LEDGERS: u32 = 17_280;
-const INSTANCE_BUMP_THRESHOLD: u32 = DAY_IN_LEDGERS;
-const INSTANCE_EXTEND_TO: u32 = DAY_IN_LEDGERS * 30; // 30 days
-const PERSISTENT_BUMP_THRESHOLD: u32 = DAY_IN_LEDGERS;
-const PERSISTENT_EXTEND_TO: u32 = DAY_IN_LEDGERS * 365; // 1 year
 
 // ---------------------------------------------------------------------------
 // Errors

--- a/contracts/learn_token/src/test.rs
+++ b/contracts/learn_token/src/test.rs
@@ -245,8 +245,81 @@ proptest! {
     }
 }
 
-#[test]
-fn get_version_returns_semver() {
+    // Property-based tests for arithmetic invariants
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        // 1) Repeated mints to a single account should only increase balance
+        //    and total supply by the exact minted amounts (no decreases, no hidden fees).
+        #[test]
+        fn prop_repeated_mints_preserve_balance(amounts in prop::collection::vec(1i128..1_000_000i128, 1..20)) {
+            let e = Env::default();
+            let (_, _, client) = setup(&e);
+            let learner = Address::generate(&e);
+
+            let mut sum: i128 = 0;
+            for a in amounts.iter() {
+                client.mint(&learner, a);
+                sum = sum.checked_add(*a).expect("sum should not overflow with generated bounds");
+                // balance equals sum of all mints so far
+                assert_eq!(client.balance(&learner), sum);
+                // total supply equals sum across all accounts (only one account used here)
+                assert_eq!(client.total_supply(), sum);
+            }
+        }
+
+        // 2) Multiple accounts: total supply equals sum of all account balances
+        #[test]
+        fn prop_multiple_accounts_supply_consistent(
+            a in prop::collection::vec(1i128..1_000_000i128, 1..10),
+            b in prop::collection::vec(1i128..1_000_000i128, 1..10),
+        ) {
+            let e = Env::default();
+            let (_, _, client) = setup(&e);
+            let alice = Address::generate(&e);
+            let bob = Address::generate(&e);
+
+            let sum_a: i128 = a.iter().copied().sum();
+            let sum_b: i128 = b.iter().copied().sum();
+
+            for x in a.iter() { client.mint(&alice, x); }
+            for x in b.iter() { client.mint(&bob, x); }
+
+            assert_eq!(client.balance(&alice), sum_a);
+            assert_eq!(client.balance(&bob), sum_b);
+            assert_eq!(client.total_supply(), sum_a + sum_b);
+        }
+
+        // 3) Reputation is monotonic with balance: higher balance => reputation >= lower
+        #[test]
+        fn prop_reputation_monotonic(
+            a in prop::collection::vec(1i128..1_000_000i128, 1..10),
+            b in prop::collection::vec(1i128..1_000_000i128, 1..10),
+        ) {
+            let e = Env::default();
+            let (_, _, client) = setup(&e);
+            let alice = Address::generate(&e);
+            let bob = Address::generate(&e);
+
+            let sum_a: i128 = a.iter().copied().sum();
+            let sum_b: i128 = b.iter().copied().sum();
+
+            for x in a.iter() { client.mint(&alice, x); }
+            for x in b.iter() { client.mint(&bob, x); }
+
+            let rep_a = client.reputation_score(&alice);
+            let rep_b = client.reputation_score(&bob);
+
+            if sum_a >= sum_b {
+                assert!(rep_a >= rep_b);
+            } else {
+                assert!(rep_b >= rep_a);
+            }
+        }
+    }
+
+    #[test]
+    fn get_version_returns_semver() {
     let e = Env::default();
     let (_, _, client) = setup(&e);
     let version = client.get_version();


### PR DESCRIPTION
This pull request introduces property-based tests to improve the coverage and robustness of the `learn_token` contract, and also removes some unused storage constants from the codebase. The main focus is on ensuring key arithmetic and reputation invariants for the token contract, making it more reliable and maintainable.

### Testing improvements

* Added property-based tests using `proptest!` in `contracts/learn_token/src/test.rs` to verify that repeated mints only increase balances and total supply, total supply equals the sum of all account balances, and that reputation scores are monotonic with respect to balances.

### Code cleanup

* Removed unused storage constants, including `DAY_IN_LEDGERS`, `INSTANCE_BUMP_THRESHOLD`, and `INSTANCE_EXTEND_TO`, from `contracts/learn_token/src/lib.rs` to reduce clutter and potential confusion.

Closes #583 
