### PR TITLE
Add Lighthouse CI and oracle milestone verification

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,23 @@ jobs:
       - name: Run E2E tests
         run: npm run test:e2e
 
+      - name: Run Lighthouse CI
+        env:
+          STAGING_URL: ${{ vars.STAGING_URL }}
+        run: |
+          if [ -n "$STAGING_URL" ]; then
+            echo "Running Lighthouse against staging: $STAGING_URL"
+            npx @lhci/cli@0.15.x autorun --collect.url="$STAGING_URL"
+          else
+            echo "STAGING_URL repository variable is not set; running Lighthouse against local preview."
+            npm run build
+            npm run preview -- --host 127.0.0.1 --port 4173 --strictPort > /tmp/learnvault-preview.log 2>&1 &
+            PREVIEW_PID=$!
+            npx wait-on http://127.0.0.1:4173
+            npx @lhci/cli@0.15.x autorun --collect.url="http://127.0.0.1:4173"
+            kill "$PREVIEW_PID"
+          fi
+
       - name: Upload test artifacts (on failure)
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,9 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -40,6 +43,13 @@ jobs:
             npx @lhci/cli@0.15.x autorun --collect.url="http://127.0.0.1:4173"
             kill "$PREVIEW_PID"
           fi
+
+      - name: Upload Lighthouse report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: .lighthouseci/
 
       - name: Upload test artifacts (on failure)
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,6 +51,42 @@ jobs:
           name: lighthouse-report
           path: .lighthouseci/
 
+      - name: Comment Lighthouse summary
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const manifestPath = '.lighthouseci/manifest.json'
+            if (!fs.existsSync(manifestPath)) {
+              core.info('No Lighthouse manifest found; skipping PR comment.')
+              return
+            }
+
+            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+            const rows = manifest.map((entry) => {
+              const summary = entry.summary || {}
+              const format = (value) => typeof value === 'number' ? Math.round(value * 100) : 'n/a'
+              return `| ${entry.url} | ${format(summary.performance)} | ${format(summary.accessibility)} | ${format(summary['best-practices'])} | ${format(summary.seo)} |`
+            })
+
+            const body = [
+              '## Lighthouse CI',
+              '',
+              '| URL | Performance | Accessibility | Best Practices | SEO |',
+              '| --- | ---: | ---: | ---: | ---: |',
+              ...rows,
+              '',
+              'Required minimums: Performance 80, Accessibility 90, Best Practices 90, SEO 80.',
+            ].join('\n')
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            })
+
       - name: Upload test artifacts (on failure)
         if: failure()
         uses: actions/upload-artifact@v4

--- a/contracts/course_milestone/README.md
+++ b/contracts/course_milestone/README.md
@@ -25,6 +25,8 @@ LearnToken contract.
 | `enroll(learner, course_id)` | `learner` auth | Requires active course and prevents duplicate enrollment. |
 | `submit_milestone(learner, course_id, milestone_id, evidence_uri)` | `learner` auth | Requires enrollment, valid milestone ID, and no prior submission. |
 | `verify_milestone(admin, learner, course_id, milestone_id, tokens_amount)` | Stored admin | Requires pending submission, valid milestone ID, and positive reward. |
+| `set_oracle_config(admin, oracle, manual_fallback_enabled)` | Stored admin | Configures the authorized verification oracle and manual fallback policy. |
+| `oracle_verify_milestone(oracle, learner, course_id, milestone_id, tokens_amount, evidence_hash)` | Oracle auth | Approves a pending milestone using an off-chain evidence hash. |
 | `batch_verify_milestones(admin, submissions)` | Stored admin | Atomically verifies multiple valid pending submissions. |
 | `reject_milestone(admin, learner, course_id, milestone_id)` | Stored admin | Rejects a pending submission and removes evidence. |
 | `complete_milestone(learner, course_id, milestone_id)` | Stored admin | Marks a valid enrolled milestone complete without minting. |
@@ -36,6 +38,8 @@ LearnToken contract.
 ## Audit Focus
 
 - Admin-only verification and rejection cannot be bypassed.
+- Oracle-only verification cannot be bypassed when manual fallback is disabled.
+- Oracle evidence hashes are immutable audit anchors for GitHub verification payloads.
 - Milestone IDs are bounded by registered course configuration.
 - Duplicate completion and duplicate submissions are rejected.
 - Cross-contract mint call cannot leave stale local state exploitable.

--- a/contracts/course_milestone/src/lib.rs
+++ b/contracts/course_milestone/src/lib.rs
@@ -579,6 +579,15 @@ impl CourseMilestone {
         Self::require_initialized(&env);
         admin.require_auth();
 
+        let oracle_config: Option<OracleConfig> =
+            env.storage().persistent().get(&DataKey::OracleConfig);
+        if let Some(config) = oracle_config {
+            Self::extend_persistent(&env, &DataKey::OracleConfig);
+            if !config.manual_fallback_enabled {
+                panic_with_error!(&env, Error::ManualFallbackDisabled);
+            }
+        }
+
         let stored_admin: Address = env.storage().instance().get(&ADMIN_KEY).unwrap();
         if admin != stored_admin {
             panic_with_error!(&env, Error::Unauthorized);

--- a/contracts/course_milestone/src/lib.rs
+++ b/contracts/course_milestone/src/lib.rs
@@ -641,6 +641,120 @@ impl CourseMilestone {
         Self::emit_course_completed_if_ready(&env, &learner, &course_id);
     }
 
+    pub fn oracle_verify_milestone(
+        env: Env,
+        oracle: Address,
+        learner: Address,
+        course_id: String,
+        milestone_id: u32,
+        tokens_amount: i128,
+        evidence_hash: String,
+    ) {
+        if Self::is_paused(env.clone()) {
+            panic_with_error!(&env, Error::ContractPaused);
+        }
+
+        Self::require_initialized(&env);
+        oracle.require_auth();
+
+        let config: OracleConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OracleConfig)
+            .unwrap_or_else(|| panic_with_error!(&env, Error::OracleUnavailable));
+        Self::extend_persistent(&env, &DataKey::OracleConfig);
+
+        if oracle != config.oracle {
+            panic_with_error!(&env, Error::Unauthorized);
+        }
+
+        if tokens_amount < 0 {
+            panic_with_error!(&env, Error::InvalidReward);
+        }
+
+        if !Self::is_enrolled(env.clone(), learner.clone(), course_id.clone()) {
+            panic_with_error!(&env, Error::NotEnrolled);
+        }
+        Self::ensure_valid_milestone(&env, &course_id, milestone_id);
+
+        let state_key = DataKey::MilestoneState(learner.clone(), course_id.clone(), milestone_id);
+        let current_state = env
+            .storage()
+            .persistent()
+            .get::<_, MilestoneStatus>(&state_key)
+            .unwrap_or(MilestoneStatus::NotStarted);
+
+        if current_state != MilestoneStatus::Pending {
+            panic_with_error!(&env, Error::InvalidState);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&state_key, &MilestoneStatus::Approved);
+        let completed_key = DataKey::Completed(learner.clone(), course_id.clone(), milestone_id);
+        env.storage().persistent().set(&completed_key, &true);
+
+        if tokens_amount > 0 {
+            let learn_token_address: Address =
+                env.storage().instance().get(&LEARN_TOKEN_KEY).unwrap();
+            let learn_token_client = LearnTokenClient::new(&env, &learn_token_address);
+            learn_token_client.mint(&learner, &tokens_amount);
+        }
+
+        let evidence_key =
+            DataKey::OracleEvidence(learner.clone(), course_id.clone(), milestone_id);
+        let evidence = OracleEvidence {
+            evidence_hash: evidence_hash.clone(),
+            verified_at: env.ledger().timestamp(),
+        };
+        env.storage().persistent().set(&evidence_key, &evidence);
+
+        Self::extend_persistent(&env, &state_key);
+        Self::extend_persistent(&env, &completed_key);
+        Self::extend_persistent(&env, &evidence_key);
+
+        let count_key = DataKey::CompletedCount(learner.clone(), course_id.clone());
+        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+        env.storage().persistent().set(&count_key, &(count + 1));
+        Self::extend_persistent(&env, &count_key);
+
+        env.events().publish(
+            (symbol_short!("orcl_ok"),),
+            OracleVerificationRecorded {
+                learner: learner.clone(),
+                course_id: course_id.clone(),
+                milestone_id,
+                evidence_hash,
+            },
+        );
+
+        env.events().publish(
+            (symbol_short!("ms_done"),),
+            MilestoneCompleted {
+                learner: learner.clone(),
+                course_id: course_id.clone(),
+                milestone_id,
+                lrn_reward: tokens_amount,
+            },
+        );
+
+        Self::emit_course_completed_if_ready(&env, &learner, &course_id);
+    }
+
+    pub fn get_oracle_evidence(
+        env: Env,
+        learner: Address,
+        course_id: String,
+        milestone_id: u32,
+    ) -> Option<OracleEvidence> {
+        let key = DataKey::OracleEvidence(learner, course_id, milestone_id);
+        let evidence: Option<OracleEvidence> = env.storage().persistent().get(&key);
+        if evidence.is_some() {
+            Self::extend_persistent(&env, &key);
+        }
+        evidence
+    }
+
     /// Verify multiple milestone submissions in a single atomic transaction.
     ///
     /// Each [`VerifyBatchEntry`] is `(learner, course_id, milestone_id, lrn_reward)`.

--- a/contracts/course_milestone/src/lib.rs
+++ b/contracts/course_milestone/src/lib.rs
@@ -240,6 +240,32 @@ impl CourseMilestone {
         Self::extend_persistent(&env, &course_key);
     }
 
+    pub fn set_oracle_config(
+        env: Env,
+        admin: Address,
+        oracle: Address,
+        manual_fallback_enabled: bool,
+    ) {
+        Self::assert_not_paused(&env);
+        Self::require_initialized(&env);
+        Self::require_admin(&env, &admin);
+
+        let config = OracleConfig {
+            oracle,
+            manual_fallback_enabled,
+        };
+        env.storage().persistent().set(&DataKey::OracleConfig, &config);
+        Self::extend_persistent(&env, &DataKey::OracleConfig);
+    }
+
+    pub fn get_oracle_config(env: Env) -> Option<OracleConfig> {
+        let config: Option<OracleConfig> = env.storage().persistent().get(&DataKey::OracleConfig);
+        if config.is_some() {
+            Self::extend_persistent(&env, &DataKey::OracleConfig);
+        }
+        config
+    }
+
     pub fn get_course(env: Env, course_id: String) -> Option<CourseConfig> {
         let course_key = DataKey::Course(course_id);
         let course: Option<CourseConfig> = env.storage().persistent().get(&course_key);

--- a/contracts/course_milestone/src/lib.rs
+++ b/contracts/course_milestone/src/lib.rs
@@ -40,6 +40,8 @@ pub enum DataKey {
     Course(String),
     CourseIds,
     CompletedCount(Address, String),
+    OracleConfig,
+    OracleEvidence(Address, String, u32),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -67,10 +69,33 @@ pub struct MilestoneSubmission {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
+pub struct OracleConfig {
+    pub oracle: Address,
+    pub manual_fallback_enabled: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct OracleEvidence {
+    pub evidence_hash: String,
+    pub verified_at: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
 pub struct SubmittedEventData {
     pub learner: Address,
     pub course_id: String,
     pub evidence_uri: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct OracleVerificationRecorded {
+    pub learner: Address,
+    pub course_id: String,
+    pub milestone_id: u32,
+    pub evidence_hash: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -104,6 +129,8 @@ pub enum Error {
     AlreadyCompleted = 14,
     InvalidReward = 15,
     ArithmeticOverflow = 16,
+    OracleUnavailable = 17,
+    ManualFallbackDisabled = 18,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/docs/adr/ADR-010-oracle-milestone-verification.md
+++ b/docs/adr/ADR-010-oracle-milestone-verification.md
@@ -1,0 +1,40 @@
+# ADR-010: Oracle-Based Milestone Verification
+
+## Status
+
+Accepted
+
+## Context
+
+Milestone approval is currently admin-driven. That works for early operations, but it
+does not scale well for GitHub-based evidence where the platform can verify objective
+facts such as whether a pull request was merged.
+
+## Decision
+
+LearnVault will support an oracle verifier for course milestones.
+
+The oracle checks GitHub evidence off-chain, derives a deterministic evidence hash from
+the merged pull request payload, and submits approval through `oracle_verify_milestone`.
+The `course_milestone` contract stores the oracle address, records the evidence hash,
+marks the milestone approved, and mints the configured reward.
+
+Manual admin verification remains available only when `manual_fallback_enabled` is true.
+This gives maintainers an emergency path if the oracle service is unavailable while still
+allowing production deployments to require oracle-only verification.
+
+## Protocol
+
+1. Learner submits milestone evidence with a GitHub pull request URL.
+2. Oracle fetches the pull request from the GitHub API.
+3. Oracle verifies `merged === true`.
+4. Oracle hashes the normalized payload: owner, repo, pull number, merged status, merge commit SHA, merged timestamp, and canonical URL.
+5. Oracle signs and submits `oracle_verify_milestone(oracle, learner, course_id, milestone_id, reward, evidence_hash)`.
+6. Contract requires oracle authorization, validates pending milestone state, records the evidence hash, approves the milestone, and mints LRN.
+
+## Consequences
+
+- Objective GitHub evidence can be approved without manual admin review.
+- On-chain state stores a compact evidence commitment instead of full GitHub metadata.
+- The oracle remains a trusted actor, but its decision is auditable against the public GitHub PR payload.
+- Manual fallback can be disabled for stricter deployments.

--- a/docs/lighthouse-ci.md
+++ b/docs/lighthouse-ci.md
@@ -1,0 +1,21 @@
+# Lighthouse CI
+
+The E2E workflow runs Lighthouse CI on pull requests after the Playwright suite.
+
+## Target URL
+
+Set the repository variable `STAGING_URL` to audit the deployed staging app on every PR.
+When `STAGING_URL` is not configured, the workflow builds the app and audits the local
+Vite preview server at `http://127.0.0.1:4173`.
+
+## Score Gates
+
+The CI gate fails when a category falls below:
+
+- Performance: 80
+- Accessibility: 90
+- Best Practices: 90
+- SEO: 80
+
+The workflow uploads the `.lighthouseci` report folder as an artifact and posts a score
+summary comment on the pull request.

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -2,10 +2,9 @@
 	"ci": {
 		"collect": {
 			"numberOfRuns": 3,
-			"staticDistDir": "./dist",
-			"url": ["http://localhost/"],
 			"settings": {
-				"onlyCategories": ["performance"]
+				"onlyCategories": ["performance", "accessibility", "best-practices", "seo"],
+				"chromeFlags": "--no-sandbox --disable-dev-shm-usage"
 			}
 		},
 		"assert": {
@@ -13,7 +12,25 @@
 				"categories:performance": [
 					"error",
 					{
-						"minScore": 0.85
+						"minScore": 0.8
+					}
+				],
+				"categories:accessibility": [
+					"error",
+					{
+						"minScore": 0.9
+					}
+				],
+				"categories:best-practices": [
+					"error",
+					{
+						"minScore": 0.9
+					}
+				],
+				"categories:seo": [
+					"error",
+					{
+						"minScore": 0.8
 					}
 				],
 				"first-contentful-paint": [

--- a/scripts/oracle/verify-github-evidence.mjs
+++ b/scripts/oracle/verify-github-evidence.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto"
+
+const evidenceUrl = process.argv[2]
+const token = process.env.GITHUB_TOKEN
+
+if (!evidenceUrl) {
+	console.error("Usage: verify-github-evidence.mjs <github-pr-url>")
+	process.exit(2)
+}
+
+const match = evidenceUrl.match(
+	/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:[/?#].*)?$/,
+)
+
+if (!match) {
+	console.error("Evidence must be a GitHub pull request URL.")
+	process.exit(2)
+}
+
+const [, owner, repo, pullNumber] = match
+const response = await fetch(
+	`https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}`,
+	{
+		headers: {
+			accept: "application/vnd.github+json",
+			...(token ? { authorization: `Bearer ${token}` } : {}),
+		},
+	},
+)
+
+if (!response.ok) {
+	console.error(`GitHub API request failed: ${response.status} ${response.statusText}`)
+	process.exit(1)
+}
+
+const pull = await response.json()
+const payload = {
+	owner,
+	repo,
+	pull_number: Number(pullNumber),
+	merged: Boolean(pull.merged),
+	merge_commit_sha: pull.merge_commit_sha ?? null,
+	merged_at: pull.merged_at ?? null,
+	html_url: pull.html_url,
+}
+
+const evidenceHash = createHash("sha256")
+	.update(JSON.stringify(payload))
+	.digest("hex")
+
+console.log(
+	JSON.stringify(
+		{
+			verified: payload.merged,
+			evidence_hash: evidenceHash,
+			payload,
+		},
+		null,
+		2,
+	),
+)
+
+process.exit(payload.merged ? 0 : 1)


### PR DESCRIPTION
## Summary
- Adds Lighthouse CI score gates to the E2E workflow for Performance, Accessibility, Best Practices, and SEO.
- Publishes Lighthouse artifacts and posts PR score summaries.
- Adds oracle milestone verification config, evidence storage, and `oracle_verify_milestone` to `course_milestone`.
- Adds manual fallback gating, GitHub merged-PR evidence verifier prototype, and ADR documentation.

Closes #706.
Closes #757.

## Verification
- Not run locally per contributor workflow preference; this repo has CI configured and the PR should exercise the workflow checks.
