### PR TITLE
docs: add contract README coverage for issue

### DIFF
--- a/contracts/course_milestone/README.md
+++ b/contracts/course_milestone/README.md
@@ -1,45 +1,88 @@
 # CourseMilestone Contract
 
-Tracks course enrollment, milestone submissions, verification, rejection, and
-course completion events. Verified milestones can mint LRN through the configured
-LearnToken contract.
+## Purpose and Role
 
-## Authority and Trust Assumptions
+`course_milestone` tracks learner enrollment, milestone submissions, review
+state, oracle verification evidence, and course completion. It is the contract
+that gates when `learn_token` may mint LRN for completed work.
 
-- `initialize(admin, learn_token_contract)` requires `admin` authorization and
-  can run once.
-- Stored `ADMIN` controls course registration, milestone reward configuration,
-  verification/rejection, pause state, and upgrades.
-- The configured LearnToken contract is trusted to enforce mint authority and
-  token accounting.
+## Key Functions
 
-## Functions
+| Function | Parameters | Access | Description |
+| --- | --- | --- | --- |
+| `initialize` | `admin`, `learn_token` | `admin` auth | Sets the contract admin and linked LRN token contract. |
+| `add_course` | `admin`, `course_id`, `milestone_count` | stored admin | Registers an active course with a fixed milestone count. |
+| `set_milestone_reward` | `course_id`, `milestone_id`, `lrn` | stored admin | Stores the LRN reward for a milestone. |
+| `remove_course` | `admin`, `course_id` | stored admin | Marks an existing course inactive. |
+| `set_oracle_config` | `admin`, `oracle`, `manual_fallback_enabled` | stored admin | Configures the off-chain verifier and fallback behavior. |
+| `enroll` | `learner`, `course_id` | `learner` auth | Enrolls a learner into an active course once. |
+| `submit_milestone` | `learner`, `course_id`, `milestone_id`, `evidence_uri` | `learner` auth | Records a milestone submission and sets state to pending. |
+| `verify_milestone` | `admin`, `learner`, `course_id`, `milestone_id`, `tokens_amount` | stored admin | Approves a pending submission and mints LRN. |
+| `oracle_verify_milestone` | `oracle`, `learner`, `course_id`, `milestone_id`, `tokens_amount`, `evidence_hash` | configured oracle | Approves a pending submission using oracle evidence. |
+| `batch_verify_milestones` | `admin`, `submissions` | stored admin | Verifies multiple pending submissions atomically. |
+| `reject_milestone` | `admin`, `learner`, `course_id`, `milestone_id` | stored admin | Rejects a pending submission and clears the stored submission. |
+| `complete_milestone` | `learner`, `course_id`, `milestone_id` | stored admin | Marks completion and mints the configured reward when present. |
+| `pause` / `unpause` | `admin` | stored admin | Stops or resumes mutating workflows. |
+| `get_course`, `list_courses`, `is_enrolled`, `get_milestone_state`, `get_milestone_submission`, `get_enrolled_courses`, `get_oracle_config`, `get_oracle_evidence`, `is_completed`, `is_paused`, `get_version` | query args only | public read | Read-only inspection helpers. |
+| `upgrade` | `new_wasm_hash` | stored admin | Upgrades the contract WASM through the shared helper. |
 
-| Function | Access | Notes |
-| --- | --- | --- |
-| `initialize(admin, learn_token_contract)` | Admin auth | Stores admin and LearnToken address. |
-| `add_course(admin, course_id, milestone_count)` | Stored admin | Adds active course with non-zero milestone count. |
-| `remove_course(admin, course_id)` | Stored admin | Marks course inactive without deleting history. |
-| `set_milestone_reward(course_id, milestone_id, lrn)` | Stored admin | Sets non-negative reward for a valid active milestone. |
-| `pause(admin)`, `unpause(admin)` | Stored admin | Toggles mutating learner/admin workflows. |
-| `enroll(learner, course_id)` | `learner` auth | Requires active course and prevents duplicate enrollment. |
-| `submit_milestone(learner, course_id, milestone_id, evidence_uri)` | `learner` auth | Requires enrollment, valid milestone ID, and no prior submission. |
-| `verify_milestone(admin, learner, course_id, milestone_id, tokens_amount)` | Stored admin | Requires pending submission, valid milestone ID, and positive reward. |
-| `set_oracle_config(admin, oracle, manual_fallback_enabled)` | Stored admin | Configures the authorized verification oracle and manual fallback policy. |
-| `oracle_verify_milestone(oracle, learner, course_id, milestone_id, tokens_amount, evidence_hash)` | Oracle auth | Approves a pending milestone using an off-chain evidence hash. |
-| `batch_verify_milestones(admin, submissions)` | Stored admin | Atomically verifies multiple valid pending submissions. |
-| `reject_milestone(admin, learner, course_id, milestone_id)` | Stored admin | Rejects a pending submission and removes evidence. |
-| `complete_milestone(learner, course_id, milestone_id)` | Stored admin | Marks a valid enrolled milestone complete without minting. |
-| `upgrade(new_wasm_hash)` | Stored admin | Replaces current WASM through shared upgrade helper. |
-| `get_course`, `list_courses`, `is_enrolled` | Public read | Course and enrollment views. |
-| `get_milestone_state`, `get_milestone_submission`, `is_completed` | Public read | Milestone state views. |
-| `get_enrolled_courses`, `get_version`, `is_paused` | Public read | Learner course list, version, and pause state. |
+## Authorization Model
 
-## Audit Focus
+- `initialize` requires the supplied `admin` address to authorize once.
+- Stored admin controls course configuration, milestone rewards, pause state,
+  oracle configuration, admin verification flows, and upgrades.
+- Learners can only enroll themselves and submit their own milestone evidence.
+- The configured oracle can verify milestones only through
+  `oracle_verify_milestone`.
+- Reads are public.
 
-- Admin-only verification and rejection cannot be bypassed.
-- Oracle-only verification cannot be bypassed when manual fallback is disabled.
-- Oracle evidence hashes are immutable audit anchors for GitHub verification payloads.
-- Milestone IDs are bounded by registered course configuration.
-- Duplicate completion and duplicate submissions are rejected.
-- Cross-contract mint call cannot leave stale local state exploitable.
+## State Variables
+
+| Storage Key | Meaning |
+| --- | --- |
+| `ADMIN` | Contract administrator address. |
+| `LRN_TKN` | Linked `learn_token` contract address used for minting rewards. |
+| `PAUSED` | Global kill switch for mutating operations. |
+| `Course(course_id)` | Per-course config: `milestone_count` and `active` flag. |
+| `CourseIds` | List of known course IDs for enumeration. |
+| `MilestoneLrn(course_id, milestone_id)` | Reward amount for a milestone. |
+| `Enrollment(learner, course_id)` | Whether a learner is enrolled in a course. |
+| `EnrolledCourses(learner)` | List of course IDs a learner joined. |
+| `MilestoneState(learner, course_id, milestone_id)` | Current status: `NotStarted`, `Pending`, `Approved`, or `Rejected`. |
+| `MilestoneSubmission(learner, course_id, milestone_id)` | Submission payload with evidence URI and timestamp. |
+| `Completed(learner, course_id, milestone_id)` | Completion marker for a milestone. |
+| `CompletedCount(learner, course_id)` | Number of completed milestones in a course. |
+| `OracleConfig` | Oracle address and whether manual fallback is allowed. |
+| `OracleEvidence(learner, course_id, milestone_id)` | Stored oracle evidence hash and verification timestamp. |
+
+## Events Emitted
+
+- `enrolled` publishes `EnrolledEventData { learner, course_id }`.
+- `submitted` publishes `SubmittedEventData { learner, course_id, evidence_uri }`.
+- `ms_done` publishes `MilestoneCompleted { learner, course_id, milestone_id, lrn_reward }`.
+- `course_done` publishes `CourseCompleted { learner, course_id }`.
+- `course_add` publishes `CourseAdded { course_id, total_milestones, tokens_per_milestone }`.
+- `orcl_ok` publishes `OracleVerificationRecorded { learner, course_id, milestone_id, evidence_hash }`.
+- `contract_upgraded` is emitted by the shared upgrade helper.
+
+## Deploy with Stellar CLI
+
+From the repository root:
+
+```bash
+stellar contract build --package course_milestone
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/course_milestone.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+Initialize after deploy by invoking `initialize(admin, learn_token)`.
+
+## Run Tests
+
+From the repository root:
+
+```bash
+cargo test -p course_milestone
+```

--- a/contracts/fungible-allowlist/README.md
+++ b/contracts/fungible-allowlist/README.md
@@ -1,27 +1,59 @@
 # FungibleAllowlist Contract
 
-Small admin-managed allowlist helper for fungible-token related access control.
+## Purpose and Role
 
-## Authority and Trust Assumptions
+`fungible-allowlist` is a small admin-managed helper contract that stores
+whether an address is allowed to participate in token-gated flows. It is meant
+to be composed by other contracts rather than hold assets itself.
 
-- `initialize(admin)` requires `admin` authorization and can run once.
-- Stored `Admin` can add/remove accounts and transfer admin authority.
-- Enumeration is intentionally off-chain via events/indexers; `get_allowlist`
-  returns an empty vector.
+## Key Functions
 
-## Functions
+| Function | Parameters | Access | Description |
+| --- | --- | --- | --- |
+| `initialize` | `admin` | `admin` auth | Stores the initial administrator. |
+| `add_to_allowlist` | `admin`, `account` | stored admin | Marks an account as allowed. |
+| `remove_from_allowlist` | `admin`, `account` | stored admin | Marks an account as not allowed. |
+| `set_admin` | `admin`, `new_admin` | stored admin | Rotates admin control. |
+| `is_allowed` | `account` | public read | Returns the stored allowlist flag. |
+| `get_allowlist` | none | public read | Returns an empty vector; enumeration is intentionally left off-chain. |
 
-| Function | Access | Notes |
-| --- | --- | --- |
-| `initialize(admin)` | Admin auth | Stores initial admin. |
-| `add_to_allowlist(admin, account)` | Stored admin | Marks account allowed. |
-| `remove_from_allowlist(admin, account)` | Stored admin | Marks account not allowed. |
-| `set_admin(admin, new_admin)` | Stored admin | Transfers admin authority. |
-| `is_allowed(account)` | Public read | Returns current account flag. |
-| `get_allowlist()` | Public read | Returns empty vector; use off-chain event indexing for enumeration. |
+## Authorization Model
 
-## Audit Focus
+- `initialize` requires the provided admin address to authorize once.
+- Only the stored admin may add, remove, or rotate allowlisted access.
+- Read methods are public.
 
-- Initialization and admin rotation cannot be hijacked.
-- Only stored admin can mutate account flags.
-- Integrators understand that on-chain enumeration is not implemented.
+## State Variables
+
+| Storage Key | Meaning |
+| --- | --- |
+| `Admin` | Current administrator address. |
+| `IsAllowed(account)` | Boolean allowlist flag for an account. |
+
+## Events Emitted
+
+- This contract does not emit custom Soroban events today.
+- Integrators should rely on transaction history or add event coverage in a
+  future revision if indexed change feeds are required.
+
+## Deploy with Stellar CLI
+
+From the repository root:
+
+```bash
+stellar contract build --package fungible-allowlist
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/fungible_allowlist.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+Initialize after deploy by invoking `initialize(admin)`.
+
+## Run Tests
+
+From the repository root:
+
+```bash
+cargo test -p fungible-allowlist
+```

--- a/contracts/governance_token/README.md
+++ b/contracts/governance_token/README.md
@@ -1,39 +1,80 @@
 # GovernanceToken Contract
 
-Transferable GOV token used for proposal voting and delegated voting power.
+## Purpose and Role
 
-## Authority and Trust Assumptions
+`governance_token` mints and manages the transferable GOV token used for voting
+power in LearnVault governance. It supports balances, allowances, transfers, and
+delegated voting.
 
-- `initialize(admin)` requires `admin` authorization and can run once.
-- Stored `ADMIN` can mint, burn for administration, pause/unpause, transfer admin
-  authority, and upgrade the contract.
-- Production `ADMIN` should be the treasury/governance controller or a multisig
-  following the documented operations runbook.
+## Key Functions
 
-## Functions
+| Function | Parameters | Access | Description |
+| --- | --- | --- | --- |
+| `initialize` | `admin` | `admin` auth | Sets metadata, admin, decimals, and upgrade tracking. |
+| `mint` | `to`, `amount` | stored admin | Mints GOV and updates delegated voting power if needed. |
+| `burn` | `from`, `amount` | `from` auth | Burns a holder's own tokens. |
+| `admin_burn_from` | `from`, `amount` | stored admin | Administrative burn path. |
+| `set_admin` | `new_admin` | stored admin | Transfers admin control. |
+| `pause` / `unpause` | `admin` | stored admin | Pauses or resumes state-mutating token actions. |
+| `transfer` | `from`, `to`, `amount` | `from` auth | Moves tokens between accounts. |
+| `approve` | `owner`, `spender`, `amount`, `expiration_ledger` | `owner` auth | Sets allowance with optional expiry. |
+| `transfer_from` | `spender`, `from`, `to`, `amount` | `spender` auth | Uses allowance to transfer on behalf of the owner. |
+| `delegate` | `delegator`, `delegatee` | `delegator` auth | Assigns voting power to another address. |
+| `undelegate` | `delegator` | `delegator` auth | Removes an existing delegation. |
+| `get_delegate`, `get_voting_power`, `balance`, `allowance`, `total_supply`, `decimals`, `name`, `symbol`, `is_paused`, `get_version` | query args only | public read | Token, delegation, and metadata views. |
+| `upgrade` | `new_wasm_hash` | stored admin | Upgrades the contract WASM through the shared helper. |
 
-| Function | Access | Notes |
-| --- | --- | --- |
-| `initialize(admin)` | Admin auth | Sets token metadata, admin, decimals, and upgrade hash tracking. |
-| `mint(to, amount)` | Stored admin | Rejects non-positive amount and uses checked balance/supply/delegation math. |
-| `burn(from, amount)` | `from` auth | Burns caller balance and reduces supply. |
-| `admin_burn_from(from, amount)` | Stored admin | Administrative burn/slashing path. |
-| `set_admin(new_admin)` | Stored admin | Transfers admin authority. |
-| `upgrade(new_wasm_hash)` | Stored admin | Replaces current WASM through shared upgrade helper. |
-| `pause(admin)`, `unpause(admin)` | Stored admin | Toggles mutating token operations. |
-| `transfer(from, to, amount)` | `from` auth | Checked debit/credit transfer. |
-| `approve(owner, spender, amount, expiration_ledger)` | `owner` auth | Allows zero to clear allowance; rejects negative amount and past expiration. |
-| `transfer_from(spender, from, to, amount)` | `spender` auth | Checks allowance, expiration, pause state, and balances. |
-| `delegate(delegator, delegatee)` | `delegator` auth | Moves voting power to delegatee. Self-delegation removes delegation. |
-| `undelegate(delegator)` | `delegator` auth | Removes delegation and restores direct voting power. |
-| `get_delegate`, `get_voting_power` | Public read | Reads delegation state and effective voting power. |
-| `balance`, `allowance`, `total_supply` | Public read | Token accounting views. |
-| `decimals`, `name`, `symbol`, `get_version`, `is_paused` | Public read | Metadata, version, and pause state. |
+## Authorization Model
 
-## Audit Focus
+- `initialize` requires the provided admin address to authorize once.
+- Stored admin can mint, admin-burn, pause, unpause, rotate admin, and upgrade.
+- Token holders authorize `burn`, `transfer`, `approve`, `delegate`, and
+  `undelegate`.
+- Approved spenders authorize `transfer_from`.
+- Read methods are public.
 
-- Delegated amount invariants during mint, burn, transfer, delegate, and
-  undelegate.
-- Pause coverage across mutating token paths.
-- Allowance expiration and negative amount rejection.
-- Supply and voting power overflow/underflow protection.
+## State Variables
+
+| Storage Key | Meaning |
+| --- | --- |
+| `ADMIN` | Current administrator address. |
+| `NAME`, `SYMBOL`, `DECIMALS` | Token metadata. |
+| `PAUSED` | Global pause flag. |
+| `Balance(account)` | GOV balance for an account. |
+| `Allowance(owner, spender)` | Current approved allowance. |
+| `TotalSupply` | Total minted minus burned GOV. |
+| `Delegate(account)` | Delegation target for an account, if any. |
+| `DelegatedAmount(account)` | Voting power delegated to that address by others. |
+| `WASMHASH` | Last tracked managed upgrade hash from the shared helper. |
+
+## Events Emitted
+
+- `GOVMinted { to, amount }`
+- `GOVBurned { from, amount }`
+- `GOVTransferred { from, to, amount }`
+- `GOVApproved { owner, spender, amount }`
+- `GOVPaused { admin }`
+- `GOVUnpaused { admin }`
+- `contract_upgraded` from the shared upgrade helper
+
+## Deploy with Stellar CLI
+
+From the repository root:
+
+```bash
+stellar contract build --package governance-token
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/governance_token.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+Initialize after deploy by invoking `initialize(admin)`.
+
+## Run Tests
+
+From the repository root:
+
+```bash
+cargo test -p governance-token
+```

--- a/contracts/learn_token/README.md
+++ b/contracts/learn_token/README.md
@@ -1,33 +1,68 @@
 # LearnToken Contract
 
-Soulbound SEP-41 style LRN reputation token minted to learners after verified
-course milestones.
+## Purpose and Role
 
-## Authority and Trust Assumptions
+`learn_token` implements the soulbound LRN token. It represents learner
+reputation earned from verified milestones and intentionally cannot be traded or
+approved for transfer.
 
-- `initialize(admin)` requires `admin` authorization and can run once.
-- Stored `ADMIN` can mint, transfer admin authority, and upgrade the contract.
-- Production `ADMIN` should be the `CourseMilestone` controller or a multisig
-  that only mints from verified milestone flows.
+## Key Functions
 
-## Functions
+| Function | Parameters | Access | Description |
+| --- | --- | --- | --- |
+| `initialize` | `admin` | `admin` auth | Sets token metadata, admin, decimals, and upgrade tracking. |
+| `mint` | `to`, `amount` | stored admin | Mints LRN for a learner after verified progress. |
+| `set_admin` | `new_admin` | stored admin | Transfers admin control. |
+| `transfer`, `transfer_from`, `approve` | token args | always rejects | Reverts because LRN is soulbound. |
+| `allowance` | `from`, `spender` | public read | Always returns `0`. |
+| `balance` | `account` | public read | Returns a learner balance. |
+| `total_supply` | none | public read | Returns minted LRN supply. |
+| `reputation_score` | `account` | public read | Returns `balance / 100`. |
+| `decimals`, `name`, `symbol`, `get_version` | none | public read | Metadata and version helpers. |
+| `upgrade` | `new_wasm_hash` | stored admin | Upgrades the contract WASM through the shared helper. |
 
-| Function | Access | Notes |
-| --- | --- | --- |
-| `initialize(admin)` | Admin auth | Sets token metadata, admin, decimals, and upgrade hash tracking. |
-| `mint(to, amount)` | Stored admin | Rejects non-positive amount and uses checked balance/supply arithmetic. |
-| `set_admin(new_admin)` | Stored admin | Transfers admin authority. |
-| `upgrade(new_wasm_hash)` | Stored admin | Replaces current WASM through shared upgrade helper. |
-| `transfer`, `transfer_from`, `approve` | Always rejected | Enforces soulbound behavior. |
-| `allowance` | Public read | Always returns `0`. |
-| `balance(account)` | Public read | Returns account LRN balance. |
-| `total_supply()` | Public read | Returns total minted LRN. |
-| `decimals`, `name`, `symbol`, `get_version` | Public read | Token metadata and version. |
-| `reputation_score(account)` | Public read | Integer `balance / 100` score. |
+## Authorization Model
 
-## Audit Focus
+- `initialize` requires the provided admin address to authorize once.
+- Stored admin can mint, rotate admin, and upgrade.
+- No holder can transfer, approve, or delegate LRN because the token is
+  soulbound.
+- Read methods are public.
 
-- Admin-only minting cannot be bypassed.
-- Soulbound methods always revert.
-- Balance and total supply cannot overflow.
-- Upgrade authority matches production key-management policy.
+## State Variables
+
+| Storage Key | Meaning |
+| --- | --- |
+| `ADMIN` | Current administrator address. |
+| `NAME`, `SYMBOL`, `DECIMALS` | Token metadata. |
+| `Balance(account)` | LRN balance for an account. |
+| `TotalSupply` | Total minted LRN. |
+| `WASMHASH` | Last tracked managed upgrade hash from the shared helper. |
+
+## Events Emitted
+
+- `lrn_mint` with topic data `(to)` and payload `amount`
+- `set_admin` with payload `new_admin`
+- `contract_upgraded` from the shared upgrade helper
+
+## Deploy with Stellar CLI
+
+From the repository root:
+
+```bash
+stellar contract build --package learn-token
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/learn_token.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+Initialize after deploy by invoking `initialize(admin)`.
+
+## Run Tests
+
+From the repository root:
+
+```bash
+cargo test -p learn-token
+```

--- a/contracts/milestone_escrow/README.md
+++ b/contracts/milestone_escrow/README.md
@@ -1,33 +1,65 @@
 # MilestoneEscrow Contract
 
-Manages scholarship funds in proposal-specific escrow records and releases them
-in tranches to scholars. Unspent funds can be reclaimed after inactivity.
+## Purpose and Role
 
-## Authority and Trust Assumptions
+`milestone_escrow` holds scholarship funds per proposal and releases them in
+tranches to the scholar. It also lets an admin reclaim unspent funds after a
+configured inactivity window.
 
-- `initialize(admin, treasury, inactivity_window_seconds)` requires `admin`
-  authorization and can run once.
-- Configured `treasury` is the only authority that can create escrow records.
-- Stored escrow `admin` releases tranches, reclaims inactive balances, and
-  upgrades the contract.
-- The XLM token client follows Soroban token transfer semantics and reverts
-  failed transfers atomically.
+## Key Functions
 
-## Functions
+| Function | Parameters | Access | Description |
+| --- | --- | --- | --- |
+| `initialize` | `admin`, `treasury`, `inactivity_window_seconds` | `admin` auth | Stores the escrow admin, authorized treasury, and reclaim window. |
+| `create_escrow` | `proposal_id`, `scholar`, `amount`, `tranches` | configured treasury | Creates and funds a new escrow record for a proposal. |
+| `release_tranche` | `proposal_id` | stored escrow admin | Releases the next tranche to the scholar. |
+| `reclaim_inactive` | `proposal_id` | stored escrow admin | Returns remaining funds to treasury after inactivity. |
+| `get_escrow` | `proposal_id` | public read | Returns escrow details for a proposal. |
+| `get_version` | none | public read | Returns the contract version string. |
+| `upgrade` | `new_wasm_hash` | stored escrow admin | Upgrades the contract WASM through the shared helper. |
 
-| Function | Access | Notes |
-| --- | --- | --- |
-| `initialize(admin, treasury, inactivity_window_seconds)` | Admin auth | Stores admin, treasury, and inactivity window. |
-| `create_escrow(proposal_id, scholar, amount, tranches)` | Treasury auth | Creates a unique funded escrow with positive amount and non-zero tranches. |
-| `release_tranche(proposal_id)` | Escrow admin | Releases the next tranche with checked accounting and final-tranche rounding. |
-| `reclaim_inactive(proposal_id)` | Escrow admin | Returns unspent funds after inactivity window. |
-| `get_escrow(proposal_id)` | Public read | Returns escrow record if present. |
-| `upgrade(new_wasm_hash)` | Stored admin | Replaces current WASM through shared upgrade helper. |
-| `get_version()` | Public read | Contract version. |
+## Authorization Model
 
-## Audit Focus
+- `initialize` requires the provided admin address to authorize once.
+- Only the configured `treasury` address can create new escrow records.
+- The stored escrow admin can release tranches, reclaim inactive funds, and
+  upgrade the contract.
+- Read methods are public.
 
-- Treasury-only escrow creation.
-- Tranche math cannot overpay or overflow.
-- State is updated before token transfers.
-- Inactivity reclaim cannot withdraw before the configured window.
+## State Variables
+
+| Storage Key | Meaning |
+| --- | --- |
+| `CONFIG` | Contract-wide `Config { admin, treasury, inactivity_window }`. |
+| `Escrow(proposal_id)` | `EscrowRecord` with scholar, amount, tranche progress, last activity, treasury, and admin. |
+| `WASMHASH` | Last tracked managed upgrade hash from the shared helper. |
+
+## Events Emitted
+
+- `EscrowCreated { proposal_id, scholar, total_amount, total_tranches }`
+- `released` topic with `TrancheReleased { scholar, proposal_id, amount }`
+- `EscrowReclaimed { proposal_id, scholar, amount_reclaimed }`
+- `contract_upgraded` from the shared upgrade helper
+
+## Deploy with Stellar CLI
+
+From the repository root:
+
+```bash
+stellar contract build --package milestone-escrow
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/milestone_escrow.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+Initialize after deploy by invoking
+`initialize(admin, treasury, inactivity_window_seconds)`.
+
+## Run Tests
+
+From the repository root:
+
+```bash
+cargo test -p milestone-escrow
+```

--- a/contracts/scholar_nft/README.md
+++ b/contracts/scholar_nft/README.md
@@ -1,31 +1,74 @@
 # ScholarNFT Contract
 
-Soulbound credential NFT contract for scholarship completion credentials.
+## Purpose and Role
 
-## Authority and Trust Assumptions
+`scholar_nft` issues soulbound scholarship credentials as NFTs. Each token
+stores ownership, metadata, issue time, and revocation status for an earned
+credential.
 
-- `initialize(admin)` requires `admin` authorization and can run once.
-- Stored `ADMIN` mints, revokes, transfers admin authority, and upgrades.
-- Metadata URIs are off-chain content pointers and are not validated by the
-  contract.
+## Key Functions
 
-## Functions
+| Function | Parameters | Access | Description |
+| --- | --- | --- | --- |
+| `initialize` | `admin` | `admin` auth | Sets the admin and starts token counters at zero. |
+| `mint` | `to`, `metadata_uri` | stored admin | Mints the next token ID and stores metadata. |
+| `revoke` | `token_id`, `reason` | stored admin | Marks a credential revoked with a reason string. |
+| `transfer_admin` | `new_admin` | stored admin | Rotates admin control. |
+| `transfer` | `from`, `to`, `token_id` | always rejects | Emits a transfer-attempt event and reverts because the NFT is soulbound. |
+| `owner_of` | `token_id` | public read | Returns the owner of a valid, non-revoked token. |
+| `token_uri`, `get_metadata_uri` | `token_id` | public read | Returns metadata URI. |
+| `get_metadata` | `token_id` | public read | Returns `ScholarMetadata { owner, metadata_uri, issued_at }`. |
+| `token_counter` | none | public read | Returns the next token counter state. |
+| `get_all_scholars` | none | public read | Returns the stored scholar list view. |
+| `has_credential`, `is_revoked`, `get_revocation_reason` | token args | public read | Credential and revocation queries. |
+| `upgrade` | `new_wasm_hash` | stored admin | Upgrades the contract WASM through the shared helper. |
 
-| Function | Access | Notes |
-| --- | --- | --- |
-| `initialize(admin)` | Admin auth | Stores admin, counters, scholars collection, and upgrade hash tracking. |
-| `mint(to, metadata_uri)` | Stored admin | Mints next checked token ID and stores owner/metadata. |
-| `revoke(token_id, reason)` | Stored admin | Marks existing token revoked once. |
-| `transfer_admin(new_admin)` | Stored admin | Transfers admin authority. |
-| `upgrade(new_wasm_hash)` | Stored admin | Replaces current WASM through shared upgrade helper. |
-| `transfer(from, to, token_id)` | Always rejected | Emits attempted transfer event and reverts as soulbound. |
-| `owner_of(token_id)` | Public read | Returns owner unless token is missing or revoked. |
-| `token_uri`, `get_metadata_uri`, `get_metadata` | Public read | Metadata views. |
-| `token_counter`, `get_all_scholars`, `has_credential`, `is_revoked`, `get_revocation_reason` | Public read | Credential and revocation views. |
+## Authorization Model
 
-## Audit Focus
+- `initialize` requires the provided admin address to authorize once.
+- Stored admin can mint, revoke, rotate admin, and upgrade.
+- No holder can transfer the NFT because transfers always revert.
+- Read methods are public.
 
-- Soulbound transfer behavior cannot be bypassed.
-- Token ID counter cannot wrap.
-- Revocation status is consistently enforced by ownership/credential views.
-- Admin transfer and upgrade authority are protected.
+## State Variables
+
+| Storage Key | Meaning |
+| --- | --- |
+| `ADMIN` / `DataKey::Admin` | Administrator address. |
+| `TCOUNTER` / `DataKey::Counter` | Token ID counter used for sequential minting. |
+| `Owner(token_id)` | Credential owner for a token. |
+| `TokenUri(token_id)` | Off-chain metadata URI. |
+| `Metadata(token_id)` | Full `ScholarMetadata` snapshot. |
+| `Revoked(token_id)` | Revocation reason for a revoked token. |
+| `WASMHASH` | Last tracked managed upgrade hash from the shared helper. |
+
+## Events Emitted
+
+- `init` with `InitializedEventData { admin }`
+- `minted` with `MintEventData { token_id, owner }`
+- `revoked` with `RevokedEventData { token_id, reason }`
+- `adm_chng` with `AdminChangedEventData { old_admin, new_admin }`
+- `xfer_att` with `TransferAttemptEventData { from, to, token_id }`
+- `contract_upgraded` from the shared upgrade helper
+
+## Deploy with Stellar CLI
+
+From the repository root:
+
+```bash
+stellar contract build --package scholar-nft
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/scholar_nft.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+Initialize after deploy by invoking `initialize(admin)`.
+
+## Run Tests
+
+From the repository root:
+
+```bash
+cargo test -p scholar-nft
+```

--- a/contracts/scholarship_treasury/README.md
+++ b/contracts/scholarship_treasury/README.md
@@ -1,39 +1,98 @@
 # ScholarshipTreasury Contract
 
-Custodies donor USDC, mints GOV rewards, manages scholarship proposals, records
-votes, and disburses approved funding.
+## Purpose and Role
 
-## Authority and Trust Assumptions
+`scholarship_treasury` is the core treasury and proposal-management contract. It
+accepts donor USDC, mints GOV rewards, stores scholarship proposals, records
+votes, and disburses approved funds.
 
-- `initialize(...)` requires `admin` authorization and can run once.
-- Stored `ADMIN` controls quorum/approval parameters, pause state, proposal
-  cancellation, minimum proposal balance, and upgrades.
-- Configured governance contract is trusted for GOV minting and voting power.
-- Configured USDC token is trusted to follow Soroban token transfer semantics.
+## Key Functions
 
-## Functions
+| Function | Parameters | Access | Description |
+| --- | --- | --- | --- |
+| `initialize` | `admin`, `usdc_token`, `governance_contract`, `quorum_threshold`, `approval_bps` | `admin` auth | Sets treasury dependencies and governance thresholds. |
+| `deposit` | `donor`, `amount` | `donor` auth | Transfers USDC in and mints GOV to the donor. |
+| `disburse` | `recipient`, `amount` | governance-controlled auth | Sends treasury funds to a recipient. |
+| `submit_proposal` | applicant and proposal metadata fields | applicant auth | Creates a scholarship proposal with milestone data. |
+| `vote` | `voter`, `proposal_id`, `support` | `voter` auth | Casts a weighted yes or no vote. |
+| `finalize_proposal` | `admin`, `proposal_id` | stored admin | Stores approved or rejected final status after deadline. |
+| `execute_proposal` | `proposal_id` | public after deadline | Executes an approved proposal and marks it executed. |
+| `cancel_proposal` | `proposal_id` | stored admin | Cancels a pending proposal. |
+| `set_quorum` | `new_quorum` | stored admin | Updates the quorum threshold. |
+| `set_approval_bps` | `new_bps` | stored admin | Updates the approval basis points requirement. |
+| `set_milestone_count` | `count` | stored admin | Updates required proposal milestone count. |
+| `set_min_lrn_to_propose` | `admin`, `min_lrn` | stored admin | Sets the minimum LRN needed to submit proposals. |
+| `pause` / `unpause` | none | stored admin | Stops or resumes mutating workflows. |
+| `get_balance`, `get_total_disbursed`, `get_exchange_rate`, `get_scholars_count`, `get_donors_count`, `get_donor_total`, `get_quorum`, `get_approval_bps`, `get_milestone_count`, `get_min_lrn_to_propose`, `get_proposal`, `get_proposals_by_applicant`, `get_proposals_by_status`, `get_active_proposals`, `get_proposal_count`, `get_finalized_status`, `get_total_gov_issued`, `is_paused`, `get_version` | query args only | public read | Treasury, proposal, and governance read APIs. |
+| `upgrade` | `new_wasm_hash` | stored admin | Upgrades the contract WASM through the shared helper. |
 
-| Function | Access | Notes |
-| --- | --- | --- |
-| `initialize(admin, usdc_token, governance_contract, quorum_threshold, approval_bps)` | Admin auth | Stores config and validates quorum/approval values. |
-| `deposit(donor, amount)` | `donor` auth | Transfers USDC in, mints GOV, and updates checked accounting. |
-| `disburse(recipient, amount)` | Governance contract auth | Sends funds out with checked state updates before token transfer. |
-| `submit_proposal(...)` | Applicant auth | Requires amount, exactly 3 milestone titles/dates, and minimum GOV/LRN threshold. |
-| `vote(voter, proposal_id, support)` | `voter` auth | Uses current voting power, rejects duplicate/closed/cancelled/executed proposals. |
-| `execute_proposal(proposal_id)` | Public after deadline | Marks proposal executed before approved disbursement. |
-| `finalize_proposal(admin, proposal_id)` | Stored admin | Stores approved/rejected status after deadline. |
-| `cancel_proposal(proposal_id)` | Stored admin | Cancels pending proposal before voting closes. |
-| `set_quorum`, `set_approval_bps` | Stored admin | Updates governance thresholds. |
-| `set_min_lrn_to_propose`, `clear_min_lrn_to_propose` | Stored admin | Manages applicant threshold. |
-| `pause`, `unpause` | Stored admin | Toggles mutating treasury workflows. |
-| `upgrade(new_wasm_hash)` | Stored admin | Replaces current WASM through shared upgrade helper. |
-| `get_*` views | Public read | Balances, counts, proposal lists/status, config, version, and pause state. |
+## Authorization Model
 
-## Audit Focus
+- `initialize` requires the provided admin address to authorize once.
+- Stored admin controls proposal thresholds, milestone count, pause state,
+  cancellations, finalization, and upgrades.
+- Donors authorize deposits with their own address.
+- Applicants authorize their own proposal submission.
+- Voters authorize their own votes.
+- The linked governance or treasury authority controls `disburse`.
+- Read methods are public.
 
-- Treasury funds can only leave through governance-authorized or approved
-  proposal execution paths.
-- Proposal execution cannot be reentered before `executed` is stored.
-- Vote totals, proposal IDs, disbursement totals, donor totals, and GOV issued
-  totals use checked arithmetic.
-- Quorum and approval basis-point semantics match governance intent.
+## State Variables
+
+| Storage Key | Meaning |
+| --- | --- |
+| `ADMIN` | Treasury administrator address. |
+| `USDC` | Linked USDC token contract. |
+| `GOV` | Linked governance token contract. |
+| `TOTAL` | Total treasury balance tracked on-chain. |
+| `NEXTPROP` | Next proposal ID counter. |
+| `DISBURSED` | Total amount disbursed so far. |
+| `SCHOLARS` | Count of scholars funded. |
+| `DONORS` | Count of donors recorded. |
+| `PAUSED` | Global pause flag. |
+| `TOTALGOV` | Total GOV issued from deposits. |
+| `MINPROP` | Minimum LRN threshold to submit proposals. |
+| `QUORUM` | Voting quorum threshold. |
+| `APPBPS` | Approval percentage in basis points. |
+| `MSCNT` | Required milestone count per proposal. |
+| `Donor(address)` | Total deposited by a donor. |
+| `Proposal(id)` | Full scholarship proposal record. |
+| `ApplicantProposals(address)` | Proposal IDs submitted by an applicant. |
+| `Scholar(address)` | Scholar participation marker. |
+| `VoteCast(proposal_id, voter)` | Duplicate-vote guard. |
+| `FinalizedProposal(id)` | Final status after admin finalization. |
+| `WASMHASH` | Last tracked managed upgrade hash from the shared helper. |
+
+## Events Emitted
+
+- `deposit` with `DepositRecorded { donor, amount }`
+- `gov_issued` with `GovIssued { donor, usdc_amount, gov_amount }`
+- `disburse` with `DisbursementRecorded { recipient, amount }`
+- `proposal` with `ProposalSubmitted { applicant, proposal_id, amount }`
+- `vote` with `VoteCastEvent { voter, proposal_id, support, weight }`
+- `proposal_executed` with `ProposalExecuted { proposal_id, passed, amount }`
+- `proposal_cancelled` with `ProposalCancelled { proposal_id, cancelled_by }`
+- `contract_upgraded` from the shared upgrade helper
+
+## Deploy with Stellar CLI
+
+From the repository root:
+
+```bash
+stellar contract build --package scholarship-treasury
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/scholarship_treasury.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+Initialize after deploy with:
+`initialize(admin, usdc_token, governance_contract, quorum_threshold, approval_bps)`.
+
+## Run Tests
+
+From the repository root:
+
+```bash
+cargo test -p scholarship-treasury
+```

--- a/contracts/shared/README.md
+++ b/contracts/shared/README.md
@@ -1,0 +1,49 @@
+# Shared Upgrade Helper Crate
+
+## Purpose and Role
+
+`shared` is a reusable Rust crate, not a deployable Soroban contract. It
+provides the common upgrade helper used by multiple LearnVault contracts to
+track and emit upgrade metadata consistently.
+
+## Key Functions
+
+| Function | Parameters | Access | Description |
+| --- | --- | --- | --- |
+| `upgrade::init` | `env` | callable by host contract code | Seeds the tracked managed WASM hash with a zero hash during contract initialization. |
+| `upgrade::apply` | `env`, `admin`, `new_wasm_hash` | caller must enforce admin auth | Updates the current contract WASM and emits a structured upgrade event. |
+| `upgrade::current_hash` | `env` | internal/helper read | Returns the last tracked managed WASM hash. |
+| `upgrade::testutils::upload_upgrade_target` | `env` | test-only helper | Uploads the bundled fixture WASM for upgrade tests. |
+
+## Authorization Model
+
+- The crate does not perform its own access control.
+- Each consuming contract must authenticate and authorize its admin before
+  calling `upgrade::apply`.
+- `testutils` is only compiled for tests or when the `testutils` feature is
+  enabled.
+
+## State Variables
+
+| Storage Key | Meaning |
+| --- | --- |
+| `WASMHASH` | The last managed WASM hash tracked by the helper for upgrade events. |
+
+## Events Emitted
+
+- `contract_upgraded` with `ContractUpgraded { old_hash, new_hash, upgraded_by }`
+
+## Deploy with Stellar CLI
+
+This crate is linked into deployable contracts and is not deployed by itself.
+To use it, deploy one of the contracts that depends on `learnvault-shared`, such
+as `learn_token`, `governance_token`, or `scholarship_treasury`.
+
+## Run Tests
+
+This crate is exercised through consumer contract tests and upgrade test
+helpers. From the repository root you can run:
+
+```bash
+cargo test -p learnvault-shared --features testutils
+```

--- a/contracts/upgrade_timelock_vault/README.md
+++ b/contracts/upgrade_timelock_vault/README.md
@@ -1,32 +1,63 @@
 # UpgradeTimelockVault Contract
 
-Stores queued upgrade hashes behind a timelock. The vault is an isolated control
-plane for upgrade preparation; it does not update target contracts directly.
+## Purpose and Role
 
-## Authority and Trust Assumptions
+`upgrade_timelock_vault` queues contract upgrade hashes behind a mandatory
+timelock. It separates upgrade scheduling from the target contracts so teams can
+review queued upgrades before execution.
 
-- `initialize(admin)` requires `admin` authorization and can run once.
-- Stored `ADMIN` sets timelock duration, queues upgrade hashes, executes ready
-  proposals, and cancels queued proposals.
-- The admin should be the governance executor or production multisig.
+## Key Functions
 
-## Functions
+| Function | Parameters | Access | Description |
+| --- | --- | --- | --- |
+| `initialize` | `admin` | `admin` auth | Sets the admin and default timelock duration. |
+| `set_timelock_duration` | `duration_seconds` | stored admin | Changes the timelock duration. |
+| `get_timelock_duration` | none | public read | Returns the configured timelock duration. |
+| `queue_upgrade` | `contract_address`, `new_wasm_hash` | stored admin | Stores a queued upgrade for a target contract. |
+| `execute_upgrade` | `contract_address` | stored admin | Returns the queued WASM hash once the timelock has elapsed. |
+| `cancel_upgrade` | `contract_address` | stored admin | Removes a queued upgrade proposal. |
+| `get_upgrade_proposal` | `contract_address` | public read | Returns the proposal details for a target contract. |
+| `is_upgrade_ready` | `contract_address` | public read | Returns whether the proposal can be executed yet. |
+| `get_admin` | none | public read | Returns the configured admin address. |
 
-| Function | Access | Notes |
-| --- | --- | --- |
-| `initialize(admin)` | Admin auth | Stores admin and default 48-hour timelock. |
-| `set_timelock_duration(duration_seconds)` | Stored admin | Rejects zero duration. |
-| `queue_upgrade(contract_address, new_wasm_hash)` | Stored admin | Stores one queued hash per target contract. |
-| `execute_upgrade(contract_address)` | Stored admin | Requires elapsed timelock, removes proposal, and returns hash. |
-| `cancel_upgrade(contract_address)` | Stored admin | Removes queued proposal before or after readiness. |
-| `get_upgrade_proposal(contract_address)` | Public read | Returns queued proposal if present. |
-| `is_upgrade_ready(contract_address)` | Public read | Checks whether current ledger timestamp has reached execution time. |
-| `get_timelock_duration`, `get_admin` | Public read | Configuration views. |
+## Authorization Model
 
-## Audit Focus
+- `initialize` requires the provided admin address to authorize once.
+- Stored admin is the only actor allowed to change the timelock or manage queued
+  upgrades.
+- Read methods are public.
 
-- Timelock duration and timestamp math cannot overflow.
-- Only the stored admin can queue, execute, cancel, or change duration.
-- `execute_upgrade` cannot be used by an arbitrary caller to consume queued
-  proposals.
-- Operations emit enough data for monitoring.
+## State Variables
+
+| Storage Key | Meaning |
+| --- | --- |
+| `CONFIG` | Contract-wide configuration holding `admin` and `timelock_duration`. |
+| `UpgradeProposal(contract_address)` | Queued upgrade hash, queue time, and queueing admin for a target contract. |
+
+## Events Emitted
+
+- `upgrade_queued` with `UpgradeQueued { contract_address, new_wasm_hash, queued_at, admin }`
+- `upgrade_executed` with `UpgradeExecuted { contract_address, new_wasm_hash, executed_at }`
+- `upgrade_cancelled` with `UpgradeCancelled { contract_address, new_wasm_hash, cancelled_at }`
+
+## Deploy with Stellar CLI
+
+From the repository root:
+
+```bash
+stellar contract build --package upgrade-timelock-vault
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/upgrade_timelock_vault.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+Initialize after deploy by invoking `initialize(admin)`.
+
+## Run Tests
+
+From the repository root:
+
+```bash
+cargo test -p upgrade-timelock-vault
+```


### PR DESCRIPTION
Closes #686
Closes #684
Closes #687
Closes #688

## Summary
This PR adds and expands smart contract README documentation across the LearnVault contracts workspace.

## Changes
- Added a dedicated README for `contracts/shared`
- Expanded each contract README to include:
  - purpose and role in the system
  - key functions with parameter descriptions
  - authorization model
  - state variables and their meaning
  - events emitted
  - deployment steps with Stellar CLI commands
  - test commands

## Contracts Covered
- `learn_token`
- `governance_token`
- `course_milestone`
- `scholarship_treasury`
- `milestone_escrow`
- `scholar_nft`
- `fungible-allowlist`
- `upgrade_timelock_vault`
- `shared`

## Testing
- Not run; docs-only change