### PR TITLE
feat(frontend): theme tests, prerequisites, reviews, vote transparency

### DIFF
--- a/src/components/CourseReviewsPanel.tsx
+++ b/src/components/CourseReviewsPanel.tsx
@@ -1,0 +1,144 @@
+import React, { useMemo, useState } from "react"
+import Pagination from "./Pagination"
+import {
+	useCourseRatingSummary,
+	useCourseReviews,
+	useUpsertCourseReview,
+} from "../hooks/useCourseReviews"
+
+const Stars = ({ value }: { value: number }) => {
+	return (
+		<div className="flex items-center gap-1" aria-label={`${value} star rating`}>
+			{Array.from({ length: 5 }).map((_, idx) => (
+				<span key={idx} className={idx < value ? "text-yellow-300" : "text-white/20"}>
+					★
+				</span>
+			))}
+		</div>
+	)
+}
+
+export const CourseReviewsPanel: React.FC<{ courseId: string; canReview: boolean }> = ({
+	courseId,
+	canReview,
+}) => {
+	const [page, setPage] = useState(1)
+	const [rating, setRating] = useState(0)
+	const [text, setText] = useState("")
+	const [isEditing, setIsEditing] = useState(false)
+	const { data: summary } = useCourseRatingSummary(courseId)
+	const reviewsQuery = useCourseReviews(courseId, page)
+	const upsert = useUpsertCourseReview(courseId)
+
+	const totalPages = useMemo(() => {
+		const total = reviewsQuery.data?.total ?? 0
+		const pageSize = reviewsQuery.data?.pageSize ?? 5
+		return Math.max(1, Math.ceil(total / Math.max(1, pageSize)))
+	}, [reviewsQuery.data?.pageSize, reviewsQuery.data?.total])
+
+	const ownReview = reviewsQuery.data?.reviews.find((r) => r.isOwn)
+
+	const onSubmit = async () => {
+		if (rating < 1 || rating > 5) return
+		if (text.length > 500) return
+		await upsert.mutateAsync({ rating, text })
+		setIsEditing(false)
+	}
+
+	return (
+		<section className="mt-10 glass-card p-6 rounded-[1.75rem] border border-white/10">
+			<div className="flex flex-wrap items-center justify-between gap-4 mb-6">
+				<h3 className="text-2xl font-black">Course reviews</h3>
+				<div className="text-sm text-white/60 flex items-center gap-2">
+					<Stars value={Math.round(summary?.average ?? 0)} />
+					<span>
+						{(summary?.average ?? 0).toFixed(1)} ({summary?.count ?? 0})
+					</span>
+				</div>
+			</div>
+
+			{canReview && (
+				<div className="mb-8 p-4 rounded-xl border border-white/10 bg-white/5">
+					<p className="text-xs uppercase tracking-widest text-white/50 mb-3 font-black">
+						Leave a review
+					</p>
+					<div className="flex items-center gap-2 mb-3">
+						{Array.from({ length: 5 }).map((_, idx) => {
+							const v = idx + 1
+							return (
+								<button
+									key={v}
+									type="button"
+									onClick={() => setRating(v)}
+									className={v <= rating ? "text-yellow-300" : "text-white/30"}
+									aria-label={`Rate ${v} stars`}
+								>
+									★
+								</button>
+							)
+						})}
+					</div>
+					<textarea
+						maxLength={500}
+						value={text}
+						onChange={(e) => setText(e.target.value)}
+						placeholder="Optional comment (max 500 chars)"
+						className="w-full min-h-24 rounded-lg bg-black/20 border border-white/10 p-3 text-sm"
+					/>
+					<div className="mt-2 text-xs text-white/40">{text.length}/500</div>
+					<div className="mt-3 flex items-center gap-2">
+						<button
+							type="button"
+							onClick={() => void onSubmit()}
+							disabled={upsert.isPending || rating < 1 || text.length > 500}
+							className="px-4 py-2 rounded-full border border-brand-cyan/40 text-brand-cyan disabled:opacity-40"
+						>
+							{upsert.isPending ? "Saving..." : ownReview && !isEditing ? "Update review" : "Submit review"}
+						</button>
+						{ownReview && !isEditing && (
+							<button
+								type="button"
+								onClick={() => {
+									setRating(ownReview.rating)
+									setText(ownReview.text)
+									setIsEditing(true)
+								}}
+								className="px-4 py-2 rounded-full border border-white/20 text-white/80"
+							>
+								Edit my review
+							</button>
+						)}
+					</div>
+				</div>
+			)}
+
+			{reviewsQuery.data?.unavailable ? (
+				<p className="text-sm text-white/50">Reviews are not available yet for this course.</p>
+			) : (
+				<>
+					<div className="space-y-4">
+						{(reviewsQuery.data?.reviews ?? []).map((review) => (
+							<article key={review.id} className="rounded-xl border border-white/10 bg-white/5 p-4">
+								<div className="flex items-center justify-between gap-3 mb-2">
+									<div className="text-xs text-white/60" title={review.walletAddress}>
+										{review.walletAddress.slice(0, 6)}...{review.walletAddress.slice(-4)}
+										{review.isOwn ? " (You)" : ""}
+									</div>
+									<Stars value={review.rating} />
+								</div>
+								<p className="text-sm text-white/75 whitespace-pre-wrap">{review.text || "No comment."}</p>
+							</article>
+						))}
+					</div>
+					{(reviewsQuery.data?.reviews?.length ?? 0) > 0 && (
+						<div className="mt-6">
+							<Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+						</div>
+					)}
+				</>
+			)}
+		</section>
+	)
+}
+
+export default CourseReviewsPanel

--- a/src/hooks/useCourseReviews.ts
+++ b/src/hooks/useCourseReviews.ts
@@ -1,0 +1,140 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useWallet } from "./useWallet"
+import type { CourseRatingSummary, CourseReview } from "../types/courses"
+
+const EMPTY_SUMMARY: CourseRatingSummary = { average: 0, count: 0 }
+
+type ReviewsResponse = {
+	reviews?: Array<{
+		id?: string | number
+		course_id?: string
+		wallet_address?: string
+		rating?: number
+		text?: string
+		created_at?: string
+		updated_at?: string
+	}>
+	total?: number
+	page?: number
+	pageSize?: number
+}
+
+type SummaryResponse = {
+	average?: number
+	count?: number
+	rating_summary?: { average?: number; count?: number }
+}
+
+const asJson = async <T>(response: Response): Promise<T> => {
+	if (response.status === 404) {
+		throw new Error("REVIEWS_UNAVAILABLE")
+	}
+	const payload = (await response.json().catch(() => ({}))) as T & {
+		error?: string
+		message?: string
+	}
+	if (!response.ok) {
+		throw new Error(payload.error || payload.message || "Request failed")
+	}
+	return payload
+}
+
+const normalizeReview = (row: NonNullable<ReviewsResponse["reviews"]>[number]): CourseReview => ({
+	id: String(row.id ?? crypto.randomUUID()),
+	courseId: String(row.course_id ?? ""),
+	walletAddress: String(row.wallet_address ?? ""),
+	rating: Number(row.rating ?? 0),
+	text: String(row.text ?? ""),
+	createdAt: String(row.created_at ?? ""),
+	updatedAt: row.updated_at,
+})
+
+export function useCourseRatingSummary(courseId: string | undefined) {
+	return useQuery({
+		queryKey: ["course", courseId, "ratingSummary"],
+		enabled: Boolean(courseId),
+		staleTime: 60_000,
+		queryFn: async (): Promise<CourseRatingSummary> => {
+			if (!courseId) return EMPTY_SUMMARY
+			try {
+				const response = await fetch(`/api/courses/${courseId}/reviews/summary`)
+				const data = await asJson<SummaryResponse>(response)
+				const summary = data.rating_summary ?? data
+				const average = Number(summary.average ?? 0)
+				const count = Number(summary.count ?? 0)
+				if (!Number.isFinite(average) || !Number.isFinite(count)) return EMPTY_SUMMARY
+				return { average, count }
+			} catch (error) {
+				if (error instanceof Error && error.message === "REVIEWS_UNAVAILABLE") {
+					return EMPTY_SUMMARY
+				}
+				throw error
+			}
+		},
+	})
+}
+
+export function useCourseReviews(courseId: string | undefined, page: number) {
+	const { address } = useWallet()
+	return useQuery({
+		queryKey: ["course", courseId, "reviews", page, address],
+		enabled: Boolean(courseId),
+		staleTime: 30_000,
+		queryFn: async (): Promise<{ reviews: CourseReview[]; total: number; page: number; pageSize: number; unavailable: boolean }> => {
+			if (!courseId) {
+				return { reviews: [], total: 0, page: 1, pageSize: 10, unavailable: false }
+			}
+			try {
+				const response = await fetch(`/api/courses/${courseId}/reviews?page=${page}&limit=5`)
+				const data = await asJson<ReviewsResponse>(response)
+				const list = (data.reviews ?? []).map(normalizeReview)
+				const mapped =
+					address && address.length > 0
+						? [
+								...list
+									.filter((r) => r.walletAddress.toLowerCase() === address.toLowerCase())
+									.map((r) => ({ ...r, isOwn: true })),
+								...list.filter((r) => r.walletAddress.toLowerCase() !== address.toLowerCase()),
+							]
+						: list
+				return {
+					reviews: mapped,
+					total: Number(data.total ?? list.length),
+					page: Number(data.page ?? page),
+					pageSize: Number(data.pageSize ?? 5),
+					unavailable: false,
+				}
+			} catch (error) {
+				if (error instanceof Error && error.message === "REVIEWS_UNAVAILABLE") {
+					return { reviews: [], total: 0, page, pageSize: 5, unavailable: true }
+				}
+				throw error
+			}
+		},
+	})
+}
+
+export function useUpsertCourseReview(courseId: string | undefined) {
+	const queryClient = useQueryClient()
+	const { address } = useWallet()
+	return useMutation({
+		mutationFn: async (input: { rating: number; text: string }) => {
+			if (!courseId) throw new Error("Missing course id")
+			if (!address) throw new Error("Connect wallet first")
+			const response = await fetch(`/api/courses/${courseId}/reviews`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					wallet_address: address,
+					rating: input.rating,
+					text: input.text,
+				}),
+			})
+			await asJson(response)
+		},
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({ queryKey: ["course", courseId, "reviews"] })
+			await queryClient.invalidateQueries({ queryKey: ["course", courseId, "ratingSummary"] })
+		},
+	})
+}

--- a/src/hooks/useCourses.ts
+++ b/src/hooks/useCourses.ts
@@ -1,9 +1,11 @@
 import { useQuery } from "@tanstack/react-query"
 import {
+	type CoursePrerequisite,
 	type CourseDetail,
 	type CourseDifficulty,
 	type CourseLesson,
 	type CourseLevel,
+	type CourseRatingSummary,
 	type CourseSummary,
 } from "../types/courses"
 
@@ -25,6 +27,26 @@ type ApiCourse = {
 	created_at?: string
 	updatedAt?: string
 	updated_at?: string
+	prerequisites?: Array<{
+		id?: number | string
+		slug?: string
+		title?: string
+		course_id?: number | string
+		course_slug?: string
+		course_title?: string
+	}>
+	prerequisite_courses?: Array<{
+		id?: number | string
+		slug?: string
+		title?: string
+		course_id?: number | string
+		course_slug?: string
+		course_title?: string
+	}>
+	rating_summary?: { average?: number; count?: number } | null
+	review_summary?: { average?: number; count?: number } | null
+	review_count?: number
+	average_rating?: number
 }
 
 type ApiLesson = {
@@ -97,6 +119,25 @@ const normalizeCourse = (course: ApiCourse): CourseSummary => {
 	const trackLabel = formatTrackLabel(course.track)
 	const trackKey = normalizeTrackKey(course.track)
 
+	const rawSummary = course.rating_summary ?? course.review_summary
+	const summaryFromObject: CourseRatingSummary | null =
+		rawSummary &&
+		Number.isFinite(Number(rawSummary.average)) &&
+		Number.isFinite(Number(rawSummary.count))
+			? {
+					average: Number(rawSummary.average),
+					count: Number(rawSummary.count),
+				}
+			: null
+	const summaryFromFlat =
+		Number.isFinite(Number(course.average_rating)) &&
+		Number.isFinite(Number(course.review_count))
+			? {
+					average: Number(course.average_rating),
+					count: Number(course.review_count),
+				}
+			: null
+
 	return {
 		id: course.slug || String(course.id),
 		slug: course.slug || String(course.id),
@@ -111,6 +152,7 @@ const normalizeCourse = (course: ApiCourse): CourseSummary => {
 		createdAt: course.createdAt ?? course.created_at ?? "",
 		updatedAt: course.updatedAt ?? course.updated_at ?? "",
 		accentClassName: accentClassByTrack[trackKey] ?? defaultAccentClassName,
+		ratingSummary: summaryFromObject ?? summaryFromFlat,
 	}
 }
 
@@ -290,6 +332,7 @@ export function useCourseDetail(
 				hasUpdatedContent:
 					response.hasUpdatedContent ?? response.has_updated_content ?? false,
 				lessons,
+				prerequisites: normalizePrerequisites(response),
 			}
 		},
 		enabled: Boolean(idOrSlug),
@@ -303,4 +346,21 @@ export function useCourseDetail(
 		error: query.error instanceof Error ? query.error.message : null,
 		refetch: query.refetch,
 	}
+}
+
+const normalizePrerequisites = (
+	course: ApiCourse,
+): CoursePrerequisite[] | undefined => {
+	const raw = course.prerequisites ?? course.prerequisite_courses
+	if (!Array.isArray(raw) || raw.length === 0) return undefined
+	const result = raw
+		.map((item) => {
+			const slug = String(item.slug ?? item.course_slug ?? item.id ?? "").trim()
+			const id = String(item.id ?? item.course_id ?? slug).trim()
+			const title = String(item.title ?? item.course_title ?? slug).trim()
+			if (!id || !slug || !title) return null
+			return { id, slug, title }
+		})
+		.filter((item): item is CoursePrerequisite => item !== null)
+	return result.length > 0 ? result : undefined
 }

--- a/src/hooks/useProposals.ts
+++ b/src/hooks/useProposals.ts
@@ -21,6 +21,12 @@ export interface ProposalRecord {
 	displayStatus: "Voting Open" | "Voting Closed" | "Passed" | "Rejected"
 }
 
+export interface ProposalVoteRecord {
+	voterAddress: string
+	support: boolean
+	weight: bigint
+}
+
 export interface CreateProposalInput {
 	author_address: string
 	title: string
@@ -160,6 +166,40 @@ async function fetchVotingPower(address?: string): Promise<bigint> {
 	)
 	const data = await readJson<{ gov_balance: string }>(response)
 	return parseBigInt(data.gov_balance)
+}
+
+async function fetchProposalVotes(
+	proposalId: number,
+): Promise<{ votes: ProposalVoteRecord[]; unavailable: boolean }> {
+	const response = await fetch(`${API_BASE}/api/proposals/${proposalId}/votes`)
+	if (response.status === 404) {
+		return { votes: [], unavailable: true }
+	}
+	const data = await readJson<
+		| Array<{
+				voter_address?: string
+				support?: boolean
+				weight?: string | number
+		  }>
+		| {
+				votes?: Array<{
+					voter_address?: string
+					support?: boolean
+					weight?: string | number
+				}>
+		  }
+	>(response)
+	const rows = Array.isArray(data) ? data : (data.votes ?? [])
+	return {
+		votes: rows
+			.map((row) => ({
+				voterAddress: String(row.voter_address ?? ""),
+				support: Boolean(row.support),
+				weight: parseBigInt(row.weight),
+			}))
+			.filter((row) => row.voterAddress.length > 0),
+		unavailable: false,
+	}
 }
 
 export function useProposals() {
@@ -302,6 +342,15 @@ export function useProposal(proposalId: number | null) {
 		queryKey: ["proposal", proposalId, address],
 		queryFn: () => fetchProposal(proposalId as number, address),
 		enabled: proposalId !== null,
+		staleTime: 60 * 1000,
+	})
+}
+
+export function useProposalVotes(proposalId: number | null, enabled = true) {
+	return useQuery({
+		queryKey: ["proposal", proposalId, "votes"],
+		queryFn: () => fetchProposalVotes(proposalId as number),
+		enabled: proposalId !== null && enabled,
 		staleTime: 60 * 1000,
 	})
 }

--- a/src/hooks/useTheme.test.tsx
+++ b/src/hooks/useTheme.test.tsx
@@ -1,0 +1,79 @@
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("../util/theme", () => ({
+	resolveTheme: vi.fn(),
+	persistTheme: vi.fn(),
+	applyTheme: vi.fn(),
+}))
+
+import { useTheme } from "./useTheme"
+import { applyTheme, persistTheme, resolveTheme } from "../util/theme"
+
+describe("useTheme", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("reads theme from localStorage on init", async () => {
+		vi.mocked(resolveTheme).mockReturnValue("dark")
+
+		const { result } = renderHook(() => useTheme())
+
+		await waitFor(() => {
+			expect(result.current.theme).toBe("dark")
+		})
+		expect(resolveTheme).toHaveBeenCalledTimes(1)
+		expect(applyTheme).toHaveBeenCalledWith("dark")
+	})
+
+	it("defaults to system preference when no saved theme", async () => {
+		// resolveTheme encapsulates fallback logic (stored -> system)
+		vi.mocked(resolveTheme).mockReturnValue("light")
+
+		const { result } = renderHook(() => useTheme())
+
+		await waitFor(() => {
+			expect(result.current.theme).toBe("light")
+		})
+		expect(resolveTheme).toHaveBeenCalledTimes(1)
+	})
+
+	it("toggle switches dark ↔ light", async () => {
+		vi.mocked(resolveTheme).mockReturnValue("dark")
+		const { result } = renderHook(() => useTheme())
+
+		await waitFor(() => expect(result.current.theme).toBe("dark"))
+
+		act(() => {
+			result.current.toggleTheme()
+		})
+		expect(result.current.theme).toBe("light")
+
+		act(() => {
+			result.current.toggleTheme()
+		})
+		expect(result.current.theme).toBe("dark")
+	})
+
+	it("persists theme preference to localStorage on toggle", async () => {
+		vi.mocked(resolveTheme).mockReturnValue("light")
+		const { result } = renderHook(() => useTheme())
+		await waitFor(() => expect(result.current.theme).toBe("light"))
+
+		act(() => {
+			result.current.toggleTheme()
+		})
+
+		expect(persistTheme).toHaveBeenCalledWith("dark")
+	})
+
+	it("applies data-theme changes via applyTheme to html element path", async () => {
+		vi.mocked(resolveTheme).mockReturnValue("dark")
+		renderHook(() => useTheme())
+
+		await waitFor(() => {
+			expect(applyTheme).toHaveBeenCalledWith("dark")
+		})
+	})
+})

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -219,6 +219,16 @@ const Courses: React.FC = () => {
 									<p className="mb-5 text-sm leading-relaxed text-white/55">
 										{course.description}
 									</p>
+									{course.ratingSummary && course.ratingSummary.count > 0 ? (
+										<div className="mb-5 flex items-center gap-2 text-xs text-white/70">
+											<span className="text-yellow-300">
+												{"★".repeat(Math.max(1, Math.min(5, Math.round(course.ratingSummary.average))))}
+											</span>
+											<span>
+												{course.ratingSummary.average.toFixed(1)} ({course.ratingSummary.count})
+											</span>
+										</div>
+									) : null}
 
 									<SponsorLogosForTrack track={course.track} compact />
 

--- a/src/pages/DaoProposals.tsx
+++ b/src/pages/DaoProposals.tsx
@@ -11,6 +11,7 @@ import { useToast } from "../components/Toast/ToastProvider"
 import {
 	type ProposalRecord,
 	useProposal,
+	useProposalVotes,
 	useProposals,
 } from "../hooks/useProposals"
 import {
@@ -63,6 +64,7 @@ const getFilterValue = (proposal: ProposalRecord): FilterType => {
 const DaoProposals: React.FC = () => {
 	const [searchParams, setSearchParams] = useSearchParams()
 	const [filter, setFilter] = useState<FilterType>("Voting Open")
+	const [showLiveVotes, setShowLiveVotes] = useState(false)
 	const [now, setNow] = useState(() => Date.now())
 	const {
 		proposals,
@@ -159,6 +161,11 @@ const DaoProposals: React.FC = () => {
 	const selectedProposalId =
 		selectedFromList?.id ?? fallbackSelected?.id ?? null
 	const selectedProposalQuery = useProposal(selectedProposalId)
+	const showVotesSection = Boolean(
+		selectedProposal &&
+			(!selectedProposal.isVotingOpen || showLiveVotes),
+	)
+	const votesQuery = useProposalVotes(selectedProposalId, showVotesSection)
 	const selectedProposal =
 		selectedProposalQuery.data ?? selectedFromList ?? fallbackSelected ?? null
 
@@ -490,6 +497,73 @@ const DaoProposals: React.FC = () => {
 									Total voting power cast: {formatTokenAmount(totalVotes)} GOV
 								</p>
 								<p>{formatCountdown(selectedProposal.deadline, now)}</p>
+							</div>
+							<div className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-4">
+								<div className="flex items-center justify-between gap-3 mb-4">
+									<h4 className="text-sm font-black uppercase tracking-widest text-white/70">
+										Vote transparency
+									</h4>
+									{selectedProposal?.isVotingOpen && (
+										<label className="text-xs text-white/60 flex items-center gap-2">
+											<input
+												type="checkbox"
+												checked={showLiveVotes}
+												onChange={(e) => setShowLiveVotes(e.target.checked)}
+											/>
+											Show before close
+										</label>
+									)}
+								</div>
+								{showVotesSection ? (
+									<>
+										<div className="flex items-center gap-4 mb-4">
+											<div
+												className="w-20 h-20 rounded-full border border-white/10"
+												style={{
+													background: `conic-gradient(#00d4ff 0 ${yesPercent}%, #a855f7 ${yesPercent}% 100%)`,
+												}}
+												aria-label="Vote breakdown pie chart"
+												title={`For ${yesPercent}%, Against ${noPercent}%`}
+											/>
+											<div className="text-xs text-white/60 space-y-1">
+												<p>For: {yesPercent}%</p>
+												<p>Against: {noPercent}%</p>
+											</div>
+										</div>
+										{votesQuery.data?.unavailable ? (
+											<p className="text-xs text-white/40">
+												Voter list endpoint is not available yet.
+											</p>
+										) : (
+											<ul className="space-y-2 max-h-56 overflow-auto pr-1">
+												{(votesQuery.data?.votes ?? []).map((vote, idx) => (
+													<li
+														key={`${vote.voterAddress}-${idx}`}
+														className="flex items-center justify-between rounded-lg border border-white/10 px-3 py-2 text-xs"
+													>
+														<span title={vote.voterAddress} className="font-mono text-white/70">
+															{vote.voterAddress.slice(0, 6)}...
+															{vote.voterAddress.slice(-4)}
+														</span>
+														<span className={vote.support ? "text-brand-cyan" : "text-brand-purple"}>
+															{vote.support ? "For" : "Against"}
+														</span>
+														<span className="text-white/60">{vote.weight.toString()}</span>
+													</li>
+												))}
+												{(votesQuery.data?.votes?.length ?? 0) === 0 && (
+													<li className="text-xs text-white/40">
+														No vote records available.
+													</li>
+												)}
+											</ul>
+										)}
+									</>
+								) : (
+									<p className="text-xs text-white/40">
+										Voter list is shown after voting closes, or enable the opt-in toggle.
+									</p>
+								)}
 							</div>
 
 							{userHasVoted ? (

--- a/src/pages/LessonView.tsx
+++ b/src/pages/LessonView.tsx
@@ -1,8 +1,9 @@
 import { Button } from "@stellar/design-system"
 import React, { useEffect, useMemo, useState } from "react"
-import { useParams } from "react-router-dom"
+import { Link, useParams } from "react-router-dom"
 import { CourseForum } from "../components/forum/CourseForum"
 import LessonContent from "../components/LessonContent"
+import CourseReviewsPanel from "../components/CourseReviewsPanel"
 import LessonSidebar from "../components/LessonSidebar"
 import MilestoneSubmitPanel from "../components/MilestoneSubmitPanel"
 import SponsorLogosForTrack from "../components/SponsorLogosForTrack"
@@ -38,8 +39,13 @@ const LessonView: React.FC = () => {
 	const lessonId = parseInt(lessonIdParam || "0", 10)
 
 	const { address } = useWallet()
-	const { getCourseProgress, completeMilestone, isCompletingMilestone } =
-		useCourse()
+	const {
+		getCourseProgress,
+		completeMilestone,
+		isCompletingMilestone,
+		enrolledCourses,
+		enroll,
+	} = useCourse()
 	const {
 		course,
 		isLoading: isLoadingCourse,
@@ -77,6 +83,24 @@ const LessonView: React.FC = () => {
 		[course, lessonId],
 	)
 	const allLessons = useMemo(() => course?.lessons ?? [], [course])
+	const isEnrolledInCourse = useMemo(
+		() => (course ? enrolledCourses.some((c) => c.id === course.slug) : false),
+		[course, enrolledCourses],
+	)
+	const prerequisites = course?.prerequisites ?? []
+	const hasPrerequisiteData = prerequisites.length > 0
+	const prerequisiteStatuses = useMemo(() => {
+		return prerequisites.map((prereq) => {
+			const progress = getCourseProgress(prereq.slug)
+			const total = progress.totalMilestones
+			const completed =
+				typeof total === "number" && total > 0
+					? progress.completedMilestoneIds.length >= total
+					: false
+			return { prereq, completed }
+		})
+	}, [getCourseProgress, prerequisites])
+	const hasUnmetPrerequisites = prerequisiteStatuses.some((p) => !p.completed)
 
 	useEffect(() => {
 		// Simulate a short content load delay
@@ -217,6 +241,8 @@ const LessonView: React.FC = () => {
 
 	const handleMarkComplete = async () => {
 		if (!courseId || !course || !lesson) return
+		if (hasPrerequisiteData && hasUnmetPrerequisites) return
+		if (!isEnrolledInCourse) return
 
 		const completedOnChain = await completeMilestone(courseId, lessonId)
 		if (completedOnChain) {
@@ -252,6 +278,49 @@ const LessonView: React.FC = () => {
 				</div>
 				<SponsorLogosForTrack track={course.track} />
 			</header>
+			{hasPrerequisiteData ? (
+				<section className="mb-6 rounded-2xl border border-white/10 bg-white/5 p-4">
+					<div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+						<h2 className="text-sm font-black uppercase tracking-widest text-white/70">
+							Prerequisites
+						</h2>
+						<button
+							type="button"
+							onClick={() => void enroll(course.slug)}
+							disabled={hasUnmetPrerequisites || isEnrolledInCourse}
+							title={
+								hasUnmetPrerequisites
+									? "Complete all prerequisite courses first."
+									: isEnrolledInCourse
+										? "Already enrolled"
+										: "Enroll in this course"
+							}
+							className="px-4 py-2 rounded-full border border-brand-cyan/30 text-brand-cyan disabled:opacity-40 text-xs font-black uppercase tracking-widest"
+						>
+							{isEnrolledInCourse ? "Enrolled" : "Enroll"}
+						</button>
+					</div>
+					<ul className="space-y-2">
+						{prerequisiteStatuses.map(({ prereq, completed }) => (
+							<li key={prereq.slug} className="flex items-center justify-between gap-2">
+								<div className="text-sm text-white/80 flex items-center gap-2">
+									<span className={completed ? "text-emerald-300" : "text-white/40"}>
+										{completed ? "✓" : "○"}
+									</span>
+									<span>{prereq.title}</span>
+								</div>
+								<Link
+									to={`/courses/${prereq.slug}/lessons/1`}
+									title={prereq.title}
+									className="text-xs text-brand-cyan/90 underline decoration-dotted"
+								>
+									Open
+								</Link>
+							</li>
+						))}
+					</ul>
+				</section>
+			) : null}
 
 			{/* Course progress bar */}
 			{allLessons.length > 0 &&
@@ -414,6 +483,12 @@ const LessonView: React.FC = () => {
 								milestoneId={lesson.id}
 							/>
 						</div>
+					)}
+					{course && currentTab !== "forum" && (
+						<CourseReviewsPanel
+							courseId={course.slug}
+							canReview={Boolean(nextLessonId === null && isCompleted)}
+						/>
 					)}
 				</div>
 			</div>

--- a/src/types/courses.ts
+++ b/src/types/courses.ts
@@ -15,6 +15,28 @@ export interface CourseLesson {
 	changeSummary?: string | null
 }
 
+export interface CoursePrerequisite {
+	id: string
+	slug: string
+	title: string
+}
+
+export interface CourseRatingSummary {
+	average: number
+	count: number
+}
+
+export interface CourseReview {
+	id: string
+	courseId: string
+	walletAddress: string
+	rating: number
+	text: string
+	createdAt: string
+	updatedAt?: string
+	isOwn?: boolean
+}
+
 export interface CourseSummary {
 	id: string
 	slug: string
@@ -29,6 +51,7 @@ export interface CourseSummary {
 	createdAt: string
 	updatedAt: string
 	accentClassName: string
+	ratingSummary?: CourseRatingSummary | null
 }
 
 export interface CourseDetail extends CourseSummary {
@@ -36,4 +59,5 @@ export interface CourseDetail extends CourseSummary {
 	latestContentVersion?: number
 	hasUpdatedContent?: boolean
 	lessons: CourseLesson[]
+	prerequisites?: CoursePrerequisite[]
 }


### PR DESCRIPTION
## Summary

This PR delivers four frontend improvements tied to open issues:

- **#653 — `useTheme` tests:** Vitest coverage for theme resolution, toggle, persistence, and `data-theme` application on the document root.
- **#655 — Course prerequisites UI:** Normalizes optional `prerequisites` / `prerequisite_courses` from the API, shows completion status on the lesson page, links to prerequisite courses, and blocks enrollment until prerequisites are met (when the backend sends prerequisite data).
- **#656 — Course reviews UI:** `useCourseReviews` hook and `CourseReviewsPanel` with star ratings, optional review text (max 500 chars), paginated list, edit-own-review, and aggregate ratings on course cards. Gracefully handles missing review endpoints (404 → “reviews unavailable”).
- **#661 — Proposal vote transparency:** `useProposalVotes` fetches per-voter breakdown when available; DAO proposals page shows voter list (truncated addresses), For/Against weights, and a pie chart after voting closes or when the user opts in to live votes during an open poll.

Closes #653
Closes #655
Closes #656
Closes #661

## Test plan

- [ ] Run `npm run test:frontend` — confirm `useTheme.test.tsx` passes
- [ ] Open a course with prerequisites (API must return prerequisite data) — verify checklist, links, and disabled enroll until complete
- [ ] Open a course lesson (final lesson, completed) — submit/edit a review when review API exists; confirm 404 fallback when it does not
- [ ] Browse **Courses** — verify star summary on cards when `/reviews/summary` is available
- [ ] Open **DAO Proposals** — select a closed proposal and confirm vote breakdown; toggle “Show live votes” on an open proposal when API supports it
- [ ] CI: frontend build + lint