### PR TITLE
docs: create donor guide for contributions and governance

### DIFF
--- a/docs/user-guides/donor.md
+++ b/docs/user-guides/donor.md
@@ -1,0 +1,41 @@
+# Donor Guide
+
+This guide explains how to contribute to LearnVault as a donor — from depositing funds to governing scholarship decisions.
+
+## 1. Connect as a Donor
+
+1. Install [Freighter](https://www.freighter.app/) and fund your wallet with XLM and USDC.
+2. Visit the LearnVault app and click **Connect Wallet**.
+3. Select **Freighter** and approve the connection.
+4. Navigate to the **Donor** section from the main dashboard.
+
+## 2. Deposit USDC to the Treasury
+
+1. From the Donor dashboard, click **Deposit Funds**.
+2. Enter the USDC amount you wish to contribute.
+3. Confirm the transaction in Freighter — funds are sent to the on-chain treasury contract.
+4. Your deposit is recorded and you receive governance tokens proportional to your contribution.
+
+## 3. What Governance Tokens Represent
+
+- Governance tokens (LRN) give you voting power over scholarship decisions and platform parameters.
+- Token weight is proportional to your total USDC contributed to the treasury.
+- Tokens are non-transferable and tied to your wallet address.
+- They do not represent equity or a financial return.
+
+## 4. Vote on Scholarship Proposals
+
+1. Go to **Governance** in the navigation menu.
+2. Review open proposals — each shows the scholar's application, requested amount, and milestone plan.
+3. Click **Vote Yes** or **Vote No** to cast your vote on-chain.
+4. Voting closes after the defined period; the proposal passes if quorum and majority thresholds are met.
+
+## 5. Track Funded Scholar Progress
+
+1. From the **Portfolio** tab, view all scholars funded through pools you contributed to.
+2. Each scholar card shows completed milestones, submitted evidence links, and remaining disbursements.
+3. Evidence links (GitHub + IPFS) are publicly verifiable on-chain.
+
+## 6. Tax and Compliance Disclaimer
+
+> **Disclaimer:** LearnVault does not provide tax, legal, or financial advice. USDC contributions to the treasury may have tax implications depending on your jurisdiction. Consult a qualified tax professional before making contributions. Governance tokens are utility tokens and are not classified as securities by the LearnVault protocol; however, regulatory treatment may vary by country.


### PR DESCRIPTION
Closes #693

Adds `docs/user-guides/donor.md` covering wallet connection, USDC treasury deposits, governance token meaning, voting on scholarship proposals, tracking scholar progress, and a tax/compliance disclaimer.