### PR TITLE
test: add full test suite for fungible-allowlist contract (#581)

### DIFF
--- a/contracts/fungible-allowlist/src/lib.rs
+++ b/contracts/fungible-allowlist/src/lib.rs
@@ -2,6 +2,7 @@
 
 use soroban_sdk::{
     Address, Env, Vec, contract, contracterror, contractimpl, contracttype, panic_with_error,
+    symbol_short,
 };
 
 #[contracterror]
@@ -30,6 +31,7 @@ impl FungibleAllowlist {
         }
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.events().publish((symbol_short!("init"),), admin);
     }
 
     pub fn add_to_allowlist(env: Env, admin: Address, account: Address) {
@@ -47,6 +49,7 @@ impl FungibleAllowlist {
             env.storage()
                 .persistent()
                 .set(&DataKey::IsAllowed(account.clone()), &true);
+            env.events().publish((symbol_short!("added"),), account.clone());
         }
     }
 
@@ -65,11 +68,7 @@ impl FungibleAllowlist {
             env.storage()
                 .persistent()
                 .set(&DataKey::IsAllowed(account.clone()), &false);
-            let mut list: Vec<Address> = env.storage().instance().get(&DataKey::Allowlist).unwrap();
-            if let Some(idx) = list.iter().position(|x| x == account) {
-                list.remove(idx as u32);
-                env.storage().instance().set(&DataKey::Allowlist, &list);
-            }
+            env.events().publish((symbol_short!("removed"),), account.clone());
         }
     }
 
@@ -96,73 +95,9 @@ impl FungibleAllowlist {
             panic_with_error!(&env, AllowlistError::Unauthorized);
         }
         env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.events().publish((symbol_short!("new_admin"),), new_admin);
     }
 }
 
 #[cfg(test)]
-mod test {
-    use super::*;
-    use soroban_sdk::{Env, testutils::Address as _};
-
-    #[test]
-    fn test_allowlist_flow() {
-        let env = Env::default();
-        let admin = Address::generate(&env);
-        let alice = Address::generate(&env);
-        let bob = Address::generate(&env);
-
-        let contract_id = env.register_contract(None, FungibleAllowlist);
-        let client = FungibleAllowlistClient::new(&env, &contract_id);
-
-        env.mock_all_auths();
-        client.initialize(&admin);
-        assert_eq!(client.is_allowed(&alice), false);
-        assert_eq!(client.get_allowlist().len(), 0);
-
-        client.add_to_allowlist(&admin, &alice);
-        assert_eq!(client.is_allowed(&alice), true);
-        assert_eq!(client.get_allowlist().len(), 0);
-
-        client.add_to_allowlist(&admin, &bob);
-        assert_eq!(client.is_allowed(&bob), true);
-        assert_eq!(client.get_allowlist().len(), 0);
-
-        client.remove_from_allowlist(&admin, &alice);
-        assert_eq!(client.is_allowed(&alice), false);
-        assert_eq!(client.get_allowlist().len(), 0);
-
-        let new_admin = Address::generate(&env);
-        client.set_admin(&admin, &new_admin);
-
-        client.add_to_allowlist(&new_admin, &alice);
-        assert_eq!(client.is_allowed(&alice), true);
-    }
-
-    #[test]
-    fn benchmark_costs() {
-        let env = Env::default();
-        let admin = Address::generate(&env);
-        let alice = Address::generate(&env);
-
-        let contract_id = env.register(FungibleAllowlist, ());
-        let client = FungibleAllowlistClient::new(&env, &contract_id);
-
-        // 1. Benchmark initialize
-        env.cost_estimate().budget().reset_unlimited();
-        client.initialize(&admin);
-        let init_instr = env.cost_estimate().budget().cpu_instruction_cost();
-        let init_mem = env.cost_estimate().budget().memory_bytes_cost();
-
-        // 2. Benchmark add_to_allowlist
-        env.mock_all_auths();
-        env.cost_estimate().budget().reset_unlimited();
-        client.add_to_allowlist(&admin, &alice);
-        let add_instr = env.cost_estimate().budget().cpu_instruction_cost();
-        let add_mem = env.cost_estimate().budget().memory_bytes_cost();
-
-        extern crate std;
-        std::println!("BENCHMARK_RESULTS: fungible_allowlist");
-        std::println!("initialize: instr={}, mem={}", init_instr, init_mem);
-        std::println!("add_to_allowlist: instr={}, mem={}", add_instr, add_mem);
-    }
-}
+mod test;

--- a/contracts/fungible-allowlist/src/test.rs
+++ b/contracts/fungible-allowlist/src/test.rs
@@ -1,0 +1,306 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{
+    Address, Env,
+    testutils::{Address as _, Events as _},
+};
+
+use crate::{AllowlistError, FungibleAllowlist, FungibleAllowlistClient};
+
+fn setup(env: &Env) -> (Address, Address, FungibleAllowlistClient) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(FungibleAllowlist, ());
+    env.mock_all_auths();
+    let client = FungibleAllowlistClient::new(env, &contract_id);
+    client.initialize(&admin);
+    (contract_id, admin, client)
+}
+
+// --- initialization ---
+
+#[test]
+fn initialize_sets_admin_and_emits_event() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(FungibleAllowlist, ());
+    env.mock_all_auths();
+    let client = FungibleAllowlistClient::new(&env, &contract_id);
+
+    let baseline = env.events().all().len();
+    client.initialize(&admin);
+
+    let events = env.events().all();
+    assert!(events.len() > baseline);
+    assert!(events.iter().any(|(cid, _, _)| *cid == contract_id));
+}
+
+#[test]
+fn double_initialize_is_rejected() {
+    let env = Env::default();
+    let (_, admin, client) = setup(&env);
+
+    let result = client.try_initialize(&admin);
+    assert_eq!(
+        result.err(),
+        Some(Ok(soroban_sdk::Error::from_contract_error(
+            AllowlistError::AlreadyInitialized as u32,
+        ))),
+    );
+}
+
+// --- add to allowlist ---
+
+#[test]
+fn add_to_allowlist_marks_address_as_allowed() {
+    let env = Env::default();
+    let (_, admin, client) = setup(&env);
+    let alice = Address::generate(&env);
+
+    assert!(!client.is_allowed(&alice));
+    client.add_to_allowlist(&admin, &alice);
+    assert!(client.is_allowed(&alice));
+}
+
+#[test]
+fn add_to_allowlist_emits_event() {
+    let env = Env::default();
+    let (contract_id, admin, client) = setup(&env);
+    let alice = Address::generate(&env);
+
+    let baseline = env.events().all().len();
+    client.add_to_allowlist(&admin, &alice);
+
+    let events = env.events().all();
+    assert!(events.len() > baseline);
+    assert!(events.iter().any(|(cid, _, _)| *cid == contract_id));
+}
+
+#[test]
+fn duplicate_add_is_idempotent() {
+    let env = Env::default();
+    let (_, admin, client) = setup(&env);
+    let alice = Address::generate(&env);
+
+    client.add_to_allowlist(&admin, &alice);
+    client.add_to_allowlist(&admin, &alice);
+    assert!(client.is_allowed(&alice));
+}
+
+// --- remove from allowlist ---
+
+#[test]
+fn remove_from_allowlist_marks_address_as_not_allowed() {
+    let env = Env::default();
+    let (_, admin, client) = setup(&env);
+    let alice = Address::generate(&env);
+
+    client.add_to_allowlist(&admin, &alice);
+    assert!(client.is_allowed(&alice));
+
+    client.remove_from_allowlist(&admin, &alice);
+    assert!(!client.is_allowed(&alice));
+}
+
+#[test]
+fn remove_from_allowlist_emits_event() {
+    let env = Env::default();
+    let (contract_id, admin, client) = setup(&env);
+    let alice = Address::generate(&env);
+
+    client.add_to_allowlist(&admin, &alice);
+    let baseline = env.events().all().len();
+    client.remove_from_allowlist(&admin, &alice);
+
+    let events = env.events().all();
+    assert!(events.len() > baseline);
+    assert!(events.iter().any(|(cid, _, _)| *cid == contract_id));
+}
+
+#[test]
+fn remove_non_allowlisted_address_is_noop() {
+    let env = Env::default();
+    let (_, admin, client) = setup(&env);
+    let alice = Address::generate(&env);
+
+    client.remove_from_allowlist(&admin, &alice);
+    assert!(!client.is_allowed(&alice));
+}
+
+// --- transfer gating (allowlist semantics) ---
+
+#[test]
+fn non_allowlisted_address_is_blocked() {
+    let env = Env::default();
+    let (_, _, client) = setup(&env);
+    let stranger = Address::generate(&env);
+
+    assert!(!client.is_allowed(&stranger));
+}
+
+#[test]
+fn allowlisted_address_is_permitted() {
+    let env = Env::default();
+    let (_, admin, client) = setup(&env);
+    let alice = Address::generate(&env);
+
+    client.add_to_allowlist(&admin, &alice);
+
+    assert!(client.is_allowed(&alice));
+}
+
+#[test]
+fn removed_address_is_blocked_again() {
+    let env = Env::default();
+    let (_, admin, client) = setup(&env);
+    let alice = Address::generate(&env);
+
+    client.add_to_allowlist(&admin, &alice);
+    client.remove_from_allowlist(&admin, &alice);
+
+    assert!(!client.is_allowed(&alice));
+}
+
+// --- admin controls ---
+
+#[test]
+fn non_admin_cannot_add_to_allowlist() {
+    let env = Env::default();
+    let (_, _, client) = setup(&env);
+    let attacker = Address::generate(&env);
+    let victim = Address::generate(&env);
+
+    let result = client.try_add_to_allowlist(&attacker, &victim);
+    assert_eq!(
+        result.err(),
+        Some(Ok(soroban_sdk::Error::from_contract_error(
+            AllowlistError::Unauthorized as u32,
+        ))),
+    );
+    assert!(!client.is_allowed(&victim));
+}
+
+#[test]
+fn non_admin_cannot_remove_from_allowlist() {
+    let env = Env::default();
+    let (_, admin, client) = setup(&env);
+    let alice = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.add_to_allowlist(&admin, &alice);
+
+    let result = client.try_remove_from_allowlist(&attacker, &alice);
+    assert_eq!(
+        result.err(),
+        Some(Ok(soroban_sdk::Error::from_contract_error(
+            AllowlistError::Unauthorized as u32,
+        ))),
+    );
+    assert!(client.is_allowed(&alice));
+}
+
+#[test]
+fn non_admin_cannot_set_admin() {
+    let env = Env::default();
+    let (_, _, client) = setup(&env);
+    let attacker = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    let result = client.try_set_admin(&attacker, &new_admin);
+    assert_eq!(
+        result.err(),
+        Some(Ok(soroban_sdk::Error::from_contract_error(
+            AllowlistError::Unauthorized as u32,
+        ))),
+    );
+}
+
+#[test]
+fn set_admin_transfers_admin_authority() {
+    let env = Env::default();
+    let (_, admin, client) = setup(&env);
+    let new_admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+
+    client.set_admin(&admin, &new_admin);
+
+    let result = client.try_add_to_allowlist(&admin, &alice);
+    assert!(result.is_err());
+
+    client.add_to_allowlist(&new_admin, &alice);
+    assert!(client.is_allowed(&alice));
+}
+
+// --- edge cases ---
+
+#[test]
+fn empty_allowlist_has_no_allowed_addresses() {
+    let env = Env::default();
+    let (_, _, client) = setup(&env);
+    let stranger = Address::generate(&env);
+
+    assert!(!client.is_allowed(&stranger));
+    assert_eq!(client.get_allowlist().len(), 0);
+}
+
+#[test]
+fn multiple_addresses_tracked_independently() {
+    let env = Env::default();
+    let (_, admin, client) = setup(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    client.add_to_allowlist(&admin, &alice);
+    client.add_to_allowlist(&admin, &bob);
+
+    assert!(client.is_allowed(&alice));
+    assert!(client.is_allowed(&bob));
+    assert!(!client.is_allowed(&carol));
+}
+
+#[test]
+fn add_before_initialize_is_rejected() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let contract_id = env.register(FungibleAllowlist, ());
+    env.mock_all_auths();
+    let client = FungibleAllowlistClient::new(&env, &contract_id);
+
+    let result = client.try_add_to_allowlist(&admin, &alice);
+    assert_eq!(
+        result.err(),
+        Some(Ok(soroban_sdk::Error::from_contract_error(
+            AllowlistError::NotInitialized as u32,
+        ))),
+    );
+}
+
+// --- benchmark ---
+
+#[test]
+fn benchmark_costs() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+
+    let contract_id = env.register(FungibleAllowlist, ());
+    let client = FungibleAllowlistClient::new(&env, &contract_id);
+
+    env.cost_estimate().budget().reset_unlimited();
+    env.mock_all_auths();
+    client.initialize(&admin);
+    let init_instr = env.cost_estimate().budget().cpu_instruction_cost();
+    let init_mem = env.cost_estimate().budget().memory_bytes_cost();
+
+    env.cost_estimate().budget().reset_unlimited();
+    client.add_to_allowlist(&admin, &alice);
+    let add_instr = env.cost_estimate().budget().cpu_instruction_cost();
+    let add_mem = env.cost_estimate().budget().memory_bytes_cost();
+
+    std::println!("BENCHMARK_RESULTS: fungible_allowlist");
+    std::println!("initialize: instr={}, mem={}", init_instr, init_mem);
+    std::println!("add_to_allowlist: instr={}, mem={}", add_instr, add_mem);
+}


### PR DESCRIPTION
## Problem
The [fungible-allowlist](cci:9://file:///home/dsotec/Documents/learnvault/contracts/fungible-allowlist:0:0-0:0) contract had zero effective test coverage due to
a compile error: [remove_from_allowlist](cci:1://file:///home/dsotec/Documents/learnvault/contracts/fungible-allowlist/src/lib.rs:55:4-72:5) referenced `DataKey::Allowlist`,
a variant that does not exist in the `DataKey` enum.

## Solution
- Fixed the compile error by removing the dead list-maintenance code
- Added Soroban event emissions to all state-changing functions
- Replaced the minimal inline test module with a dedicated [src/test.rs](cci:7://file:///home/dsotec/Documents/learnvault/contracts/learn_token/src/test.rs:0:0-0:0)
  following the project convention used by [learn_token](cci:9://file:///home/dsotec/Documents/learnvault/contracts/learn_token:0:0-0:0) and [governance_token](cci:9://file:///home/dsotec/Documents/learnvault/contracts/governance_token:0:0-0:0)
- Added 18 unit tests covering every item in the issue checklist

## Testing
All 18 tests are verified against the Soroban SDK testutils harness with
`mock_all_auths()` and contract error assertions using `try_*` client methods.

Closes #581 