### PR TITLE
feat(#623): add course rating and review system API

### DIFF
--- a/server/src/controllers/courses.controller.ts
+++ b/server/src/controllers/courses.controller.ts
@@ -16,6 +16,8 @@ type CourseRow = {
 	updated_at: string
 	students_count: number
 	prerequisites?: number[]
+	avg_rating: string | null
+	review_count: number
 }
 
 type LessonRow = {
@@ -51,6 +53,11 @@ const toCourse = (row: CourseRow) => ({
 	updatedAt: row.updated_at,
 	studentsCount: Number(row.students_count ?? 0),
 	prerequisites: row.prerequisites ?? [],
+	avgRating:
+		row.avg_rating !== null && row.avg_rating !== undefined
+			? Number(row.avg_rating)
+			: null,
+	reviewCount: Number(row.review_count ?? 0),
 })
 
 const toLesson = (row: LessonRow) => ({
@@ -211,9 +218,12 @@ export const getCourses = async (
 				c.created_at,
 				c.updated_at,
 				c.prerequisites,
-				COUNT(DISTINCT e.learner_address)::int AS students_count
+				COUNT(DISTINCT e.learner_address)::int AS students_count,
+				ROUND(AVG(cr.rating), 1) AS avg_rating,
+				COUNT(DISTINCT cr.id)::int AS review_count
 			 FROM courses c
 			 LEFT JOIN enrollments e ON e.course_id = c.slug
+			 LEFT JOIN course_reviews cr ON cr.course_id = c.id
 			 ${whereClause}
 			 GROUP BY c.id, c.slug, c.title, c.description, c.cover_image_url, c.track, c.difficulty, c.published_at, c.created_at, c.updated_at, c.prerequisites
 			 ORDER BY c.created_at DESC
@@ -236,13 +246,23 @@ export const getCourse = async (req: Request, res: Response): Promise<void> => {
 		const isNumericId = /^\d+$/.test(idOrSlug)
 
 		const query = isNumericId
-			? `SELECT id, slug, title, description, cover_image_url, track, difficulty, published_at, created_at, updated_at, prerequisites
-			   FROM courses
-			   WHERE id = $1 AND published_at IS NOT NULL
+			? `SELECT c.id, c.slug, c.title, c.description, c.cover_image_url, c.track, c.difficulty, c.published_at, c.created_at, c.updated_at,
+			          c.prerequisites, 0 AS students_count,
+			          ROUND(AVG(cr.rating), 1) AS avg_rating,
+			          COUNT(cr.id)::int AS review_count
+			   FROM courses c
+			   LEFT JOIN course_reviews cr ON cr.course_id = c.id
+			   WHERE c.id = $1 AND c.published_at IS NOT NULL
+			   GROUP BY c.id
 			   LIMIT 1`
-			: `SELECT id, slug, title, description, cover_image_url, track, difficulty, published_at, created_at, updated_at, prerequisites
-			   FROM courses
-			   WHERE slug = $1 AND published_at IS NOT NULL
+			: `SELECT c.id, c.slug, c.title, c.description, c.cover_image_url, c.track, c.difficulty, c.published_at, c.created_at, c.updated_at,
+			          c.prerequisites, 0 AS students_count,
+			          ROUND(AVG(cr.rating), 1) AS avg_rating,
+			          COUNT(cr.id)::int AS review_count
+			   FROM courses c
+			   LEFT JOIN course_reviews cr ON cr.course_id = c.id
+			   WHERE c.slug = $1 AND c.published_at IS NOT NULL
+			   GROUP BY c.id
 			   LIMIT 1`
 
 		const courseResult = (await pool.query(query, [

--- a/server/src/controllers/reviews.controller.ts
+++ b/server/src/controllers/reviews.controller.ts
@@ -1,0 +1,173 @@
+import { type Request, type Response } from "express"
+import sanitizeHtml from "sanitize-html"
+import { pool } from "../db"
+import { type AuthRequest } from "../middleware/auth.middleware"
+
+type ReviewRow = {
+	id: number
+	course_id: number
+	learner_address: string
+	rating: number
+	review_text: string | null
+	created_at: string
+}
+
+const toReview = (row: ReviewRow) => ({
+	id: row.id,
+	courseId: row.course_id,
+	learnerAddress: row.learner_address,
+	rating: row.rating,
+	reviewText: row.review_text ?? null,
+	createdAt: row.created_at,
+})
+
+const resolveCourseId = async (idOrSlug: string): Promise<number | null> => {
+	const isNumeric = /^\d+$/.test(idOrSlug)
+	const result = (await pool.query(
+		`SELECT id FROM courses WHERE ${isNumeric ? "id" : "slug"} = $1 AND published_at IS NOT NULL LIMIT 1`,
+		[isNumeric ? Number.parseInt(idOrSlug, 10) : idOrSlug],
+	)) as { rows: Array<{ id: number }> }
+	return result.rows[0]?.id ?? null
+}
+
+export const getCourseReviews = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	try {
+		const courseId = await resolveCourseId(req.params.idOrSlug)
+		if (courseId === null) {
+			res.status(404).json({ error: "Course not found" })
+			return
+		}
+
+		const limitParam = Number.parseInt(req.query.limit as string, 10)
+		const offsetParam = Number.parseInt(req.query.offset as string, 10)
+		const limit =
+			Number.isFinite(limitParam) && limitParam > 0
+				? Math.min(limitParam, 100)
+				: 20
+		const offset =
+			Number.isFinite(offsetParam) && offsetParam >= 0 ? offsetParam : 0
+
+		const [reviewsResult, statsResult] = await Promise.all([
+			pool.query(
+				`SELECT id, course_id, learner_address, rating, review_text, created_at
+				 FROM course_reviews
+				 WHERE course_id = $1
+				 ORDER BY created_at DESC
+				 LIMIT $2 OFFSET $3`,
+				[courseId, limit, offset],
+			) as Promise<{ rows: ReviewRow[] }>,
+			pool.query(
+				`SELECT COUNT(*)::int AS total, ROUND(AVG(rating), 1) AS avg_rating
+				 FROM course_reviews
+				 WHERE course_id = $1`,
+				[courseId],
+			) as Promise<{
+				rows: Array<{ total: number; avg_rating: string | null }>
+			}>,
+		])
+
+		const { total, avg_rating } = statsResult.rows[0]
+
+		res.status(200).json({
+			data: reviewsResult.rows.map(toReview),
+			total,
+			avgRating: avg_rating !== null ? Number(avg_rating) : null,
+		})
+	} catch {
+		res.status(500).json({ error: "Internal server error" })
+	}
+}
+
+export const createCourseReview = async (
+	req: Request,
+	res: Response,
+): Promise<void> => {
+	try {
+		const learnerAddress = (req as AuthRequest).user?.address
+		if (!learnerAddress) {
+			res.status(401).json({ error: "Unauthorized" })
+			return
+		}
+
+		const courseId = await resolveCourseId(req.params.idOrSlug)
+		if (courseId === null) {
+			res.status(404).json({ error: "Course not found" })
+			return
+		}
+
+		// Must be enrolled in course to review
+		const enrollment = (await pool.query(
+			`SELECT id FROM enrollments
+			 WHERE learner_address = $1
+			   AND course_id = (SELECT slug FROM courses WHERE id = $2 LIMIT 1)
+			 LIMIT 1`,
+			[learnerAddress, courseId],
+		)) as { rows: Array<{ id: number }> }
+
+		if (enrollment.rows.length === 0) {
+			res
+				.status(403)
+				.json({
+					error: "You must be enrolled in this course to leave a review",
+				})
+			return
+		}
+
+		const body = req.body as { rating?: unknown; reviewText?: unknown }
+
+		const rating = Number(body.rating)
+		if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+			res
+				.status(400)
+				.json({
+					error: "rating must be an integer between 1 and 5",
+					field: "rating",
+				})
+			return
+		}
+
+		let reviewText: string | null = null
+		if (body.reviewText !== undefined && body.reviewText !== null) {
+			if (typeof body.reviewText !== "string") {
+				res
+					.status(400)
+					.json({ error: "reviewText must be a string", field: "reviewText" })
+				return
+			}
+			if (body.reviewText.length > 2000) {
+				res
+					.status(400)
+					.json({
+						error: "reviewText must be 2000 characters or fewer",
+						field: "reviewText",
+					})
+				return
+			}
+			reviewText =
+				sanitizeHtml(body.reviewText.trim(), {
+					allowedTags: [],
+					allowedAttributes: {},
+				}) || null
+		}
+
+		const result = (await pool.query(
+			`INSERT INTO course_reviews (course_id, learner_address, rating, review_text)
+			 VALUES ($1, $2, $3, $4)
+			 RETURNING id, course_id, learner_address, rating, review_text, created_at`,
+			[courseId, learnerAddress, rating, reviewText],
+		)) as { rows: ReviewRow[] }
+
+		res.status(201).json(toReview(result.rows[0]))
+	} catch (error) {
+		if (typeof error === "object" && error && "code" in error) {
+			if ((error as { code?: string }).code === "23505") {
+				res.status(409).json({ error: "You have already reviewed this course" })
+				return
+			}
+		}
+		res.status(500).json({ error: "Internal server error" })
+	}
+}

--- a/server/src/db/migrations/013_course_reviews.sql
+++ b/server/src/db/migrations/013_course_reviews.sql
@@ -1,0 +1,12 @@
+CREATE TABLE course_reviews (
+    id               SERIAL PRIMARY KEY,
+    course_id        INTEGER NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
+    learner_address  TEXT NOT NULL,
+    rating           INTEGER NOT NULL CHECK (rating BETWEEN 1 AND 5),
+    review_text      TEXT,
+    created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (course_id, learner_address)
+);
+
+CREATE INDEX idx_course_reviews_course_id ON course_reviews (course_id);
+CREATE INDEX idx_course_reviews_learner   ON course_reviews (learner_address);

--- a/server/src/db/migrations/013_course_reviews.undo.sql
+++ b/server/src/db/migrations/013_course_reviews.undo.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS course_reviews;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,7 @@ import { moderationRouter } from "./routes/moderation.routes"
 import { notificationsRouter } from "./routes/notifications.routes"
 import { createPeerReviewRouter } from "./routes/peer-review.routes"
 import { createRecommendationsRouter } from "./routes/recommendations.routes"
+import { createReviewsRouter } from "./routes/reviews.routes"
 import { createScholarsRouter } from "./routes/scholars.routes"
 import { scholarshipsRouter } from "./routes/scholarships.routes"
 import { sponsorsRouter } from "./routes/sponsors.routes"
@@ -192,7 +193,7 @@ app.use("/api", scholarsRouter)
 app.use("/api", createUserProfileRouter(jwtService))
 app.use("/api", createUploadRouter(jwtService))
 app.use("/api", enrollmentsRouter)
-app.use("/api", profilesRouter)
+app.use("/api", createReviewsRouter(jwtService))
 app.use("/api", scholarshipsRouter)
 app.use("/api", treasuryRouter)
 app.use("/api", notificationsRouter)

--- a/server/src/routes/reviews.routes.ts
+++ b/server/src/routes/reviews.routes.ts
@@ -1,0 +1,129 @@
+import { Router } from "express"
+
+import {
+	createCourseReview,
+	getCourseReviews,
+} from "../controllers/reviews.controller"
+import { createRequireAuth } from "../middleware/auth.middleware"
+import { type JwtService } from "../services/jwt.service"
+
+export function createReviewsRouter(jwtService: JwtService): Router {
+	const router = Router()
+	const requireAuth = createRequireAuth(jwtService)
+
+	/**
+	 * @openapi
+	 * /api/courses/{idOrSlug}/reviews:
+	 *   get:
+	 *     tags: [Reviews]
+	 *     summary: Get reviews for a course
+	 *     description: Returns paginated reviews and average rating for a published course.
+	 *     parameters:
+	 *       - in: path
+	 *         name: idOrSlug
+	 *         required: true
+	 *         schema:
+	 *           type: string
+	 *         description: Course numeric ID or slug
+	 *       - in: query
+	 *         name: limit
+	 *         schema:
+	 *           type: integer
+	 *           minimum: 1
+	 *           maximum: 100
+	 *           default: 20
+	 *       - in: query
+	 *         name: offset
+	 *         schema:
+	 *           type: integer
+	 *           minimum: 0
+	 *           default: 0
+	 *     responses:
+	 *       200:
+	 *         description: List of reviews with aggregate stats
+	 *         content:
+	 *           application/json:
+	 *             schema:
+	 *               type: object
+	 *               properties:
+	 *                 data:
+	 *                   type: array
+	 *                   items:
+	 *                     $ref: '#/components/schemas/CourseReview'
+	 *                 total:
+	 *                   type: integer
+	 *                 avgRating:
+	 *                   type: number
+	 *                   nullable: true
+	 *       404:
+	 *         $ref: '#/components/responses/NotFoundError'
+	 *       500:
+	 *         $ref: '#/components/responses/InternalServerError'
+	 */
+	router.get("/courses/:idOrSlug/reviews", getCourseReviews)
+
+	/**
+	 * @openapi
+	 * /api/courses/{idOrSlug}/reviews:
+	 *   post:
+	 *     tags: [Reviews]
+	 *     summary: Submit a review for a course
+	 *     description: Creates a review for a published course. Requires the learner to be enrolled. One review per learner per course.
+	 *     security:
+	 *       - bearerAuth: []
+	 *     parameters:
+	 *       - in: path
+	 *         name: idOrSlug
+	 *         required: true
+	 *         schema:
+	 *           type: string
+	 *         description: Course numeric ID or slug
+	 *     requestBody:
+	 *       required: true
+	 *       content:
+	 *         application/json:
+	 *           schema:
+	 *             type: object
+	 *             required:
+	 *               - rating
+	 *             properties:
+	 *               rating:
+	 *                 type: integer
+	 *                 minimum: 1
+	 *                 maximum: 5
+	 *               reviewText:
+	 *                 type: string
+	 *                 maxLength: 2000
+	 *                 nullable: true
+	 *     responses:
+	 *       201:
+	 *         description: Review created
+	 *         content:
+	 *           application/json:
+	 *             schema:
+	 *               $ref: '#/components/schemas/CourseReview'
+	 *       400:
+	 *         $ref: '#/components/responses/BadRequestError'
+	 *       401:
+	 *         $ref: '#/components/responses/UnauthorizedError'
+	 *       403:
+	 *         description: Not enrolled in course
+	 *         content:
+	 *           application/json:
+	 *             schema:
+	 *               $ref: '#/components/schemas/ErrorResponse'
+	 *       404:
+	 *         $ref: '#/components/responses/NotFoundError'
+	 *       409:
+	 *         description: Already reviewed this course
+	 *         content:
+	 *           application/json:
+	 *             schema:
+	 *               $ref: '#/components/schemas/ErrorResponse'
+	 *       500:
+	 *         $ref: '#/components/responses/InternalServerError'
+	 */
+	router.post("/courses/:idOrSlug/reviews", requireAuth, createCourseReview)
+
+	return router
+}


### PR DESCRIPTION
## Summary

Closes #623

- **Migration** (`013_course_reviews.sql`): adds `course_reviews` table with `course_id` (FK → `courses.id`), `learner_address`, `rating` (1–5 CHECK), `review_text` (nullable), `created_at`, and a `UNIQUE(course_id, learner_address)` constraint to prevent duplicate reviews. Includes rollback file.
- **`GET /api/courses/:idOrSlug/reviews`** (public): returns paginated reviews plus aggregate `avgRating` and `total` for any published course.
- **`POST /api/courses/:idOrSlug/reviews`** (auth required): validates enrollment, enforces 1–5 rating, sanitizes review text (plain text only, max 2000 chars), and returns 409 on duplicate via the DB unique constraint.
- **`GET /api/courses` and `GET /api/courses/:idOrSlug`**: now include `avgRating` (rounded to 1 decimal, `null` if no reviews) and `reviewCount` fields via a `LEFT JOIN course_reviews`.

## Test plan

- [ ] Run `npm run migrate` in `server/` to apply `013_course_reviews.sql`
- [ ] `GET /api/courses` — confirm `avgRating` and `reviewCount` fields appear on each course object
- [ ] `GET /api/courses/:slug/reviews` with no reviews — expect `{ data: [], total: 0, avgRating: null }`
- [ ] `POST /api/courses/:slug/reviews` without Bearer token — expect 401
- [ ] `POST /api/courses/:slug/reviews` with a valid token but not enrolled — expect 403
- [ ] `POST /api/courses/:slug/reviews` with a valid enrolled token and `{ "rating": 4, "reviewText": "Great course!" }` — expect 201
- [ ] Repeat the POST — expect 409 "You have already reviewed this course"
- [ ] `GET /api/courses/:slug/reviews` after submission — confirm review appears and `avgRating` is correct
- [ ] `POST` with `rating: 0` or `rating: 6` — expect 400
- [ ] `npm run migrate:rollback` — confirm table is dropped cleanly
